### PR TITLE
Rsh/get version script

### DIFF
--- a/.azure-pipelines/buildAndPackage.yml
+++ b/.azure-pipelines/buildAndPackage.yml
@@ -82,7 +82,7 @@ steps:
       settings.gradle
       gradle.properties
       **/gradle/wrapper/*
-      Scripts/getLatestVersion.ps1
+      scripts/getLatestVersion.ps1
     TargetFolder: '$(Build.ArtifactStagingDirectory)/'
 
 - task: PublishBuildArtifacts@1

--- a/.azure-pipelines/buildAndPackage.yml
+++ b/.azure-pipelines/buildAndPackage.yml
@@ -23,6 +23,7 @@ trigger:
       - gradlew.bat
       - readme.md
       - settings.gradle
+      - Scripts/*
 
 pr: none
 

--- a/.azure-pipelines/buildAndPackage.yml
+++ b/.azure-pipelines/buildAndPackage.yml
@@ -82,6 +82,7 @@ steps:
       settings.gradle
       gradle.properties
       **/gradle/wrapper/*
+      Scripts/getLatestVersion.ps1
     TargetFolder: '$(Build.ArtifactStagingDirectory)/'
 
 - task: PublishBuildArtifacts@1

--- a/.azure-pipelines/buildAndPackage.yml
+++ b/.azure-pipelines/buildAndPackage.yml
@@ -82,7 +82,7 @@ steps:
       settings.gradle
       gradle.properties
       **/gradle/wrapper/*
-      scripts/getLatestVersion.ps1
+      Scripts/getLatestVersion.ps1
     TargetFolder: '$(Build.ArtifactStagingDirectory)/'
 
 - task: PublishBuildArtifacts@1

--- a/.azure-pipelines/prValidate.yml
+++ b/.azure-pipelines/prValidate.yml
@@ -18,6 +18,7 @@ pr:
       - gradlew.bat
       - readme.md
       - settings.gradle
+      - Scripts/*
 
 trigger: none # disable triggers based on commits.
 

--- a/.azure-pipelines/prValidate.yml
+++ b/.azure-pipelines/prValidate.yml
@@ -41,7 +41,7 @@ steps:
 - task: PowerShell@2
   condition: and(failed(), eq(variables['Build.SourceBranchName'], 'dev'))
   inputs:
-    filePath: '$(System.DefaultWorkingDirectory)\Scripts\validateMavenVersion.ps1'
+    filePath: '$(System.DefaultWorkingDirectory)\scripts\validateMavenVersion.ps1'
     pwsh: true
     arguments: '-packageName "$(PACKAGE_NAME)" -propertiesPath "$(PROPERTIES_PATH)"'
 

--- a/.azure-pipelines/prValidate.yml
+++ b/.azure-pipelines/prValidate.yml
@@ -1,4 +1,8 @@
-# Build and test Java Core to make sure a valid pull request is being made 
+  
+#Copyright (c) Microsoft Corporation. All rights reserved.
+#Licensed under the MIT License.
+#Build and test Java Core to make sure a valid pull request is being made
+#Validate that the versions dont conflict with those online in case a pull request is made to main or master
 pr: 
   branches:
     include:

--- a/.azure-pipelines/prValidate.yml
+++ b/.azure-pipelines/prValidate.yml
@@ -1,8 +1,8 @@
-  
 #Copyright (c) Microsoft Corporation. All rights reserved.
 #Licensed under the MIT License.
 #Build and test Java Core to make sure a valid pull request is being made
 #Validate that the versions dont conflict with those online in case a pull request is made to main or master
+
 pr: 
   branches:
     include:

--- a/.azure-pipelines/prValidate.yml
+++ b/.azure-pipelines/prValidate.yml
@@ -41,7 +41,7 @@ steps:
 - task: PowerShell@2
   condition: and(failed(), eq(variables['Build.SourceBranchName'], 'dev'))
   inputs:
-    filePath: '$(System.DefaultWorkingDirectory)\scripts\validateMavenVersion.ps1'
+    filePath: '$(System.DefaultWorkingDirectory)\Scripts\validateMavenVersion.ps1'
     pwsh: true
     arguments: '-packageName "$(PACKAGE_NAME)" -propertiesPath "$(PROPERTIES_PATH)"'
 

--- a/Scripts/getLatestVersion.ps1
+++ b/Scripts/getLatestVersion.ps1
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<# 
+.Synopsis
+    Retrieve the latest version of the library
+.Description 
+    Retrieves the latest version specified in the Gradle.Properties file
+    Uses the retrieved values to update the enviornment variable VERSION_STRING
+#>
+
+.Parameter propertiesPath
+
+Param(
+    [parameter(Mandatory = $true)]
+    [string]$propertiesPath,
+)
+
+#Retrieve the current version from the Gradle.Properties file given the specified path
+$file = get-item $propertiesPath
+$findVersions = $file | Select-String -Pattern "mavenMajorVersion" -Context 0,2
+$findVersions = $findVersions -split "`r`n"
+
+$majorVersion = $findVersions[0].Substring($findVersions[0].Length-1)
+$minorVersion = $findVersions[1].Substring($findVersions[1].Length-1)
+$patchVersion = $findVersions[2].Substring($findVersions[2].Length-1)
+$version = "$majorVersion.$minorVersion.$patchVersion"
+
+#Update the VERSION_STRING env variable and inform the user
+Write-Host "##vso[task.setVariable variable=VERSION_STRING]$($version)";
+Write-Host "Updated the VERSION_STRING enviornment variable with the current Gradle.Properties, $version"

--- a/Scripts/validateMavenVersion.ps1
+++ b/Scripts/validateMavenVersion.ps1
@@ -52,8 +52,8 @@ if(($mavenVersion -eq $null) -and ($bintrayVersion -eq $null))
 }
 
 #Inform host of current Maven and Bintray versions
-write-host 'The current version in the Maven central repository is:' $mavenVersion
-write-host 'The current version in the Bintray central repository is:' $bintrayVersion
+Write-Host 'The current version in the Maven central repository is:' $mavenVersion
+Write-Host 'The current version in the Bintray central repository is:' $bintrayVersion
 
 #Warn in case Maven and Bintray versions are not the same.
 if($mavenVersion -ne $bintrayVersion){

--- a/Scripts/validateMavenVersion.ps1
+++ b/Scripts/validateMavenVersion.ps1
@@ -43,6 +43,14 @@ $bintrayAPIurl = "https://api.bintray.com/search/packages?name=$packageName"
 $jsonResult = $web_client.DownloadString($bintrayAPIurl) | ConvertFrom-Json
 $bintrayVersion = [version]$jsonResult.latest_version
 
+#If the api calls return empty then this library cannot be compared to the online versions
+#may proceed with the pull request
+if(($mavenVersion -eq $null) -and ($bintrayVersion -eq $null))
+{
+    Write-Information "This package does not exist yet in the online repository, therefore there are no versions to compare."
+    return
+}
+
 #Inform host of current Maven and Bintray versions
 write-host 'The current version in the Maven central repository is:' $mavenVersion
 write-host 'The current version in the Bintray central repository is:' $bintrayVersion


### PR DESCRIPTION
I added the script 'getLatestVersion' to retrieve version in the Gradle.Properties file. The script was also included in the artifact so that it may later be accessed in the Java-Core release pipeline. This script is used to auto-tag the GH releases in the Java-Core release pipeline.
Also updated the validateMavenVersion script to take into account the case where we may not have published anything to either the Jcenter or Maven repos. This is more so a provision for any future scenarios which may occur. 