### PR TITLE
- fixes signatures publishing following upgrade

### DIFF
--- a/.azure-pipelines/buildAndPackage.yml
+++ b/.azure-pipelines/buildAndPackage.yml
@@ -77,6 +77,8 @@ steps:
     SourceFolder: '$(System.DefaultWorkingDirectory)'
     Contents: |
       **/libs/*
+      build/generated-pom.xml
+      build/generated-pom.xml.asc
       build.gradle
       gradlew
       gradlew.bat

--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier = 'javadoc'
 }
 
-signing {
-	sign configurations.archives
-}
-tasks.withType(Sign)*.enabled = mavenCentralPublishingEnabled.toBoolean()
-
 publishing {
 
     publications {
@@ -108,26 +103,9 @@ publishing {
         	pom.withXml {
         		def pomFile = file("${project.buildDir}/generated-pom.xml")
         		writeTo(pomFile)
-        		def pomAscFile = signing.sign(pomFile).signatureFiles[0]
-        		artifact(pomAscFile) {
-                    classifier = null
-                    extension = 'pom.asc'
-                }
         	}
         	artifact sourceJar
         	artifact javadocJar
-        	project.tasks.signArchives.signatureFiles.each {
-        		artifact(it) {
-        			def matcher = it.file =~ /-(sources|javadoc)\.jar\.asc$/
-        			if(matcher.find()){
-        				classifier = matcher.group(1)
-        			}
-        			else{
-        				classifier = null
-        			}
-        			extension = 'jar.asc'
-				}
-			}
 		}
     }
 	repositories {
@@ -148,7 +126,7 @@ publishing {
         maven {
             url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
             name = 'sonatype'
-            
+
             credentials {
     			if (project.rootProject.file('local.properties').exists()) {
         			Properties properties = new Properties()
@@ -189,6 +167,18 @@ publishing {
     }
 }
 
+signing {
+    sign publishing.publications.mavenCentralRelease
+}
+tasks.withType(Sign)*.enabled = mavenCentralPublishingEnabled.toBoolean()
+
+def fixAscNames = { name -> 
+    if(name.contains('pom')) {
+        "${project.property('mavenArtifactId')}-${mavenMajorVersion}.${mavenMinorVersion}.${mavenPatchVersion}.pom.asc"
+    } else {
+        name.replace('msgraph-sdk-java-core', "${project.property('mavenArtifactId')}-${mavenMajorVersion}.${mavenMinorVersion}.${mavenPatchVersion}")
+    }
+}
 bintray {
     if (project.rootProject.file('local.properties').exists()) {
         Properties properties = new Properties()
@@ -197,6 +187,17 @@ bintray {
         key = properties.getProperty('bintray.apikey')
     }
 	publications = ['mavenCentralRelease']
+    filesSpec {
+        from ('build/libs') {
+            include 'msgraph-sdk-java-core*.jar.asc'
+            rename fixAscNames
+        }
+        from ('build') {
+            include 'generated-pom.xml.asc'
+            rename fixAscNames
+        }
+        into "com/microsoft/graph/${project.property('mavenArtifactId')}/${mavenMajorVersion}.${mavenMinorVersion}.${mavenPatchVersion}/"
+    }
 	pkg {
 		repo = 'Maven'
 		name = project.property('mavenArtifactId')
@@ -287,11 +288,5 @@ gradle.taskGraph.whenReady { taskGraph ->
 model {
     tasks.generatePomFileForMavenCentralReleasePublication {
         destination = file("${project.buildDir}/generated-pom.xml")
-    }
-    tasks.publishMavenCentralReleasePublicationToMavenLocal {
-        dependsOn project.tasks.signArchives
-    }
-    tasks.publishMavenCentralReleasePublicationToSonatypeRepository {
-        dependsOn project.tasks.signArchives
     }
 }


### PR DESCRIPTION
following the upgrade we were missing some signature files (asc), this fixes the problem for both maven central and bintray