### PR TITLE
feature/pom-placeholder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,4 @@ hs_err_pid*
 
 # Maven
 /target/
-/pom.xml
 local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,14 @@ java {
     modularity.inferModulePath = true
 }
 
+sourceSets {
+    main {
+        java {
+            exclude 'pom.xml'
+        }
+    }
+}
+
 // In this section you declare where to find the dependencies of your project
 repositories {
     // Use jcenter for resolving your dependencies.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,26 @@
+<project>
+	<!-- 
+		This package file is a place holder to enable the dependency graph https://github.com/microsoftgraph/msgraph-sdk-java-core/network/dependencies
+		as the dependency graph is not compatible with gradle https://docs.github.com/en/free-pro-team@latest/github/visualizing-repository-data-with-graphs/about-the-dependency-graph#supported-package-ecosystems
+		build.gradle is the source of truth
+	-->
+	<modelVersion>4.0.0</modelVersion>
+   
+	<groupId>com.microsoft.graph</groupId>
+	<artifactId>microsoft-graph-core</artifactId>
+	<version>1.0.5</version>
+	<packaging>pom</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.6</version>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>gson</artifactId>
+			<version>3.12.1</version>
+		</dependency>
+	</dependencies>
+</project>


### PR DESCRIPTION
This adds a package file as a place holder to enable the dependency graph https://github.com/microsoftgraph/msgraph-sdk-java-core/network/dependencies
		as the dependency graph is not compatible with gradle https://docs.github.com/en/free-pro-team@latest/github/visualizing-repository-data-with-graphs/about-the-dependency-graph#supported-package-ecosystems
