### PR TITLE
- fixes a bug where regex replacement on multithreading could cross wires

### DIFF
--- a/src/main/java/com/microsoft/graph/content/MSBatchRequestContent.java
+++ b/src/main/java/com/microsoft/graph/content/MSBatchRequestContent.java
@@ -29,7 +29,7 @@ public class MSBatchRequestContent {
 
 	/*
 	 * Creates Batch request content using list provided
-	 * 
+	 *
 	 * @param batchRequestStepsArray List of batch steps for batching
 	 */
 	public MSBatchRequestContent(final List<MSBatchRequestStep> batchRequestStepsArray) {
@@ -50,7 +50,7 @@ public class MSBatchRequestContent {
 
 	/*
 	 * @param batchRequestStep Batch request step adding to batch content
-	 * 
+	 *
 	 * @return true or false based on addition or no addition of batch request step
 	 * given
 	 */
@@ -81,7 +81,7 @@ public class MSBatchRequestContent {
 
 	/*
 	 * @param requestId Id of Batch request step to be removed
-	 * 
+	 *
 	 * @return true or false based on removal or no removal of batch request step
 	 * with given id
 	 */
@@ -116,18 +116,13 @@ public class MSBatchRequestContent {
 	}
 
 	private static final Pattern protocolAndHostReplacementPattern = Pattern.compile("(?i)^http[s]?:\\/\\/graph\\.microsoft\\.com\\/(?>v1\\.0|beta)\\/?"); // (?i) case insensitive
-	private Matcher protocolAndHostReplacementMatcher; // not static to avoid multithreading issues as the object is mutable
 	private JsonObject getBatchRequestObjectFromRequestStep(final MSBatchRequestStep batchRequestStep) {
 		final JsonObject contentmap = new JsonObject();
 		contentmap.add("id", new JsonPrimitive(batchRequestStep.getRequestId()));
 
-		if(protocolAndHostReplacementMatcher == null) {
-			protocolAndHostReplacementMatcher = protocolAndHostReplacementPattern.matcher(batchRequestStep.getRequest().url().toString());
-		} else {
-			protocolAndHostReplacementMatcher = protocolAndHostReplacementMatcher.reset(batchRequestStep.getRequest().url().toString());
-		}
+        final Matcher protocolAndHostReplacementMatcher = protocolAndHostReplacementPattern.matcher(batchRequestStep.getRequest().url().toString());
 
-		final String url =  protocolAndHostReplacementMatcher.replaceAll(""); 
+		final String url =  protocolAndHostReplacementMatcher.replaceAll("");
 		contentmap.add("url", new JsonPrimitive(url));
 
 		contentmap.add("method", new JsonPrimitive(batchRequestStep.getRequest().method().toString()));
@@ -186,5 +181,5 @@ public class MSBatchRequestContent {
 		else
 			return requestBodyElement.getAsJsonObject();
 	}
-	
+
 }


### PR DESCRIPTION
- creates a new matcher inside the method instead of relying on a field to avoid multithreading issues

see #90 and #91