### PR TITLE
- fixes a bug where the telemetry header would not match the specification

### DIFF
--- a/src/main/java/com/microsoft/graph/httpcore/TelemetryHandler.java
+++ b/src/main/java/com/microsoft/graph/httpcore/TelemetryHandler.java
@@ -17,6 +17,7 @@ public class TelemetryHandler implements Interceptor{
     public static final String JAVA_VERSION_PREFIX = "java";
     public static final String ANDROID_VERSION_PREFIX = "android";
     public static final String CLIENT_REQUEST_ID = "client-request-id";
+    private static final String DEFAULT_VERSION_VALUE = "0";
 
     @Override
     public Response intercept(Chain chain) throws IOException {
@@ -30,7 +31,9 @@ public class TelemetryHandler implements Interceptor{
         final String featureUsage = "(featureUsage=" + telemetryOptions.getFeatureUsage() + ")";
         final String javaVersion = System.getProperty("java.version");
         final String androidVersion = getAndroidAPILevel();
-        final String sdkversion_value = GRAPH_VERSION_PREFIX + "/" + VERSION + " " + featureUsage + " " + JAVA_VERSION_PREFIX + "/" + javaVersion + " " + ANDROID_VERSION_PREFIX + "/" + androidVersion;
+        final String sdkversion_value = GRAPH_VERSION_PREFIX + "/" + VERSION + " " + featureUsage +
+                                                (javaVersion == DEFAULT_VERSION_VALUE ? "" : (", " + JAVA_VERSION_PREFIX + "/" + javaVersion)) +
+                                                (androidVersion == DEFAULT_VERSION_VALUE ? "" : (", " + ANDROID_VERSION_PREFIX + "/" + androidVersion));
         telemetryAddedBuilder.addHeader(SDK_VERSION, sdkversion_value);
 
         if(request.header(CLIENT_REQUEST_ID) == null) {
@@ -61,10 +64,10 @@ public class TelemetryHandler implements Interceptor{
             final Field sdkVersionField = versionClass.getField("SDK_INT");
             final Object value = sdkVersionField.get(null);
             final String valueStr = String.valueOf(value);
-            return valueStr == null || valueStr == "" ? "0" : valueStr;
+            return valueStr == null || valueStr == "" ? DEFAULT_VERSION_VALUE : valueStr;
         } catch (IllegalAccessException | ClassNotFoundException | NoSuchFieldException ex) {
             // we're not on android and return "0" to align with java version which returns "0" when running on android
-            return "0";
+            return DEFAULT_VERSION_VALUE;
         }
     }
 }

--- a/src/test/java/com/microsoft/graph/httpcore/TelemetryHandlerTest.java
+++ b/src/test/java/com/microsoft/graph/httpcore/TelemetryHandlerTest.java
@@ -33,7 +33,7 @@ public class TelemetryHandlerTest {
         final Response response = client.newCall(request).execute();
         assertNotNull(response);
         assertTrue(response.request().header(TelemetryHandler.SDK_VERSION).contains(expectedHeader));
-        assertTrue(response.request().header(TelemetryHandler.SDK_VERSION).contains(TelemetryHandler.ANDROID_VERSION_PREFIX));
+        assertTrue(!response.request().header(TelemetryHandler.SDK_VERSION).contains(TelemetryHandler.ANDROID_VERSION_PREFIX)); // Android version is not going to be present on unit tests runnning on java platform
         assertTrue(response.request().header(TelemetryHandler.SDK_VERSION).contains(TelemetryHandler.JAVA_VERSION_PREFIX));
     }
 


### PR DESCRIPTION
after a discussion with @darrelmiller it happears the header we're currently sending for the SDK version doesn't match the spec [here](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/middleware/TelemetryHandler.md#remarks)
This :
- adds comma spearation
- doesn't add the java or android product if we're not on those products