### PR TITLE
feature/batches execution

### DIFF
--- a/src/main/java/com/microsoft/graph/content/MSBatchRequestContent.java
+++ b/src/main/java/com/microsoft/graph/content/MSBatchRequestContent.java
@@ -1,7 +1,7 @@
 package com.microsoft.graph.content;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,20 +43,14 @@ public class MSBatchRequestContent {
      *
      * @param batchRequestStepsArray List of batch steps for batching
      */
-    public MSBatchRequestContent(@Nonnull final List<MSBatchRequestStep> batchRequestStepsArray) {
-        if (batchRequestStepsArray.size() > MAX_NUMBER_OF_REQUESTS)
+    public MSBatchRequestContent(@Nonnull final MSBatchRequestStep... batchRequestStepsArray) {
+        if (batchRequestStepsArray.length > MAX_NUMBER_OF_REQUESTS)
             throw new IllegalArgumentException("Number of batch request steps cannot exceed " + MAX_NUMBER_OF_REQUESTS);
 
         this.batchRequestStepsHashMap = new LinkedHashMap<>();
         for (final MSBatchRequestStep requestStep : batchRequestStepsArray)
-            addBatchRequestStep(requestStep);
-    }
-
-    /**
-     * Creates empty batch request content
-     */
-    public MSBatchRequestContent() {
-        this.batchRequestStepsHashMap = new LinkedHashMap<>();
+            if(requestStep != null)
+                addBatchRequestStep(requestStep);
     }
 
     /**
@@ -66,6 +60,8 @@ public class MSBatchRequestContent {
      * given
      */
     public boolean addBatchRequestStep(@Nonnull final MSBatchRequestStep batchRequestStep) {
+        if(batchRequestStep == null)
+            throw new IllegalArgumentException("batchRequestStep parameter cannot be null");
         if (batchRequestStepsHashMap.containsKey(batchRequestStep.getRequestId()) ||
             batchRequestStepsHashMap.size() >= MAX_NUMBER_OF_REQUESTS)
             return false;
@@ -81,11 +77,13 @@ public class MSBatchRequestContent {
      */
     @Nonnull
     public String addBatchRequestStep(@Nonnull final Request request, @Nullable final String... arrayOfDependsOnIds) {
+        if(request == null)
+            throw new IllegalArgumentException("request parameter cannot be null");
         String requestId;
         do {
             requestId = Integer.toString(ThreadLocalRandom.current().nextInt(1, Integer.MAX_VALUE));
         } while(batchRequestStepsHashMap.keySet().contains(requestId));
-        if(addBatchRequestStep(new MSBatchRequestStep(requestId, request, Arrays.asList(arrayOfDependsOnIds))))
+        if(addBatchRequestStep(new MSBatchRequestStep(requestId, request, arrayOfDependsOnIds)))
             return requestId;
         else
             throw new IllegalArgumentException("unable to add step to batch. Number of batch request steps cannot exceed " + MAX_NUMBER_OF_REQUESTS);
@@ -103,8 +101,8 @@ public class MSBatchRequestContent {
             batchRequestStepsHashMap.remove(requestId);
             removed = true;
             for (final Map.Entry<String, MSBatchRequestStep> steps : batchRequestStepsHashMap.entrySet()) {
-                if (steps.getValue() != null && steps.getValue().getArrayOfDependsOnIds() != null) {
-                    while (steps.getValue().getArrayOfDependsOnIds().remove(requestId))
+                if (steps.getValue() != null && steps.getValue().getDependsOnIds() != null) {
+                    while (steps.getValue().getDependsOnIds().remove(requestId))
                         ;
                 }
             }
@@ -112,20 +110,21 @@ public class MSBatchRequestContent {
         return removed;
     }
 
-    /**
-     * @return Batch request content's json as String
-     */
-    @Nonnull
-    public String getBatchRequestContent() {
+    private JsonObject getBatchRequestContentAsJson() {
         final JsonObject batchRequestContentMap = new JsonObject();
         final JsonArray batchContentArray = new JsonArray();
         for (final Map.Entry<String, MSBatchRequestStep> requestStep : batchRequestStepsHashMap.entrySet()) {
             batchContentArray.add(getBatchRequestObjectFromRequestStep(requestStep.getValue()));
         }
         batchRequestContentMap.add("requests", batchContentArray);
-
-        final String content = batchRequestContentMap.toString();
-        return content;
+        return batchRequestContentMap;
+    }
+    /**
+     * @return Batch request content's json as String
+     */
+    @Nonnull
+    public String getBatchRequestContent() {
+        return getBatchRequestContentAsJson().toString();
     }
 
     /**
@@ -135,12 +134,14 @@ public class MSBatchRequestContent {
      * @throws ClientException when the batch couldn't be executed because of client issues.
      */
     @Nonnull
-    public MSBatchResponseContent execute(@Nonnull final IBaseClient client) throws ClientException {
-        try {
-            return executeAsync(client).get();
-        } catch (Exception ex) {
-            throw new ClientException("Batch failed to execute", ex);
-        }
+    public MSBatchResponseContent execute(@Nonnull final IBaseClient client) {
+        final JsonObject content = getBatchRequestContentAsJson();
+        return new MSBatchResponseContent(client.getServiceRoot() + "/",
+                                        content,
+                                        client.customRequest("/$batch")
+                                                .buildRequest()
+                                                .post(content)
+                                                .getAsJsonObject());
     }
     /**
      * Executes the batch requests asynchronously and returns the response
@@ -152,11 +153,11 @@ public class MSBatchRequestContent {
         if(client == null) {
             throw new IllegalArgumentException("client parameter cannot be null");
         }
-        final String content = getBatchRequestContent();
-        return client.customRequest(client.getServiceRoot() + "/$batch", String.class)
+        final JsonObject content = getBatchRequestContentAsJson();
+        return client.customRequest("/$batch")
             .buildRequest()
             .postAsync(content)
-            .thenApply(resp -> new MSBatchResponseContent(client.getServiceRoot() + "/", content, resp));
+            .thenApply(resp -> new MSBatchResponseContent(client.getServiceRoot() + "/", content, resp.getAsJsonObject()));
     }
 
     private static final Pattern protocolAndHostReplacementPattern = Pattern.compile("(?i)^http[s]?:\\/\\/graph\\.microsoft\\.com\\/(?>v1\\.0|beta)\\/?"); // (?i) case insensitive
@@ -180,9 +181,9 @@ public class MSBatchRequestContent {
             contentmap.add("headers", headerMap);
         }
 
-        final List<String> arrayOfDependsOnIds = batchRequestStep.getArrayOfDependsOnIds();
+        final HashSet<String> arrayOfDependsOnIds = batchRequestStep.getDependsOnIds();
         if (arrayOfDependsOnIds != null) {
-            final JsonArray array = new JsonArray();
+            final JsonArray array = new JsonArray(arrayOfDependsOnIds.size());
             for (final String dependsOnId : arrayOfDependsOnIds)
                 array.add(dependsOnId);
             contentmap.add("dependsOn", array);

--- a/src/main/java/com/microsoft/graph/content/MSBatchRequestStep.java
+++ b/src/main/java/com/microsoft/graph/content/MSBatchRequestStep.java
@@ -1,6 +1,7 @@
 package com.microsoft.graph.content;
 
-import java.util.List;
+import java.util.Arrays;
+import java.util.HashSet;
 
 import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
@@ -13,7 +14,7 @@ import okhttp3.Request;
 public class MSBatchRequestStep {
     private String requestId;
     private Request request;
-    private List<String> arrayOfDependsOnIds;
+    private HashSet<String> dependsOnIds;
 
     /**
      * Initializes a batch step from a raw HTTP request
@@ -21,17 +22,17 @@ public class MSBatchRequestStep {
      * @param request the request to send in the batch
      * @param arrayOfDependsOnIds the ids of steps this step depends on
      */
-    public MSBatchRequestStep(@Nonnull final String requestId, @Nonnull final Request request, @Nullable final List<String> arrayOfDependsOnIds) {
+    public MSBatchRequestStep(@Nonnull final String requestId, @Nonnull final Request request, @Nullable final String... arrayOfDependsOnIds) {
         if(requestId == null)
             throw new IllegalArgumentException("Request Id cannot be null.");
         if(requestId.length() == 0)
             throw new IllegalArgumentException("Request Id cannot be empty.");
         if(request == null)
-            new IllegalArgumentException("Request cannot be null.");
+            throw new IllegalArgumentException("Request cannot be null.");
 
         this.requestId = requestId;
         this.request = request;
-        this.arrayOfDependsOnIds = arrayOfDependsOnIds;
+        this.dependsOnIds = new HashSet<>(Arrays.asList(arrayOfDependsOnIds));
     }
 
     /**
@@ -57,7 +58,7 @@ public class MSBatchRequestStep {
      * @return the list of steps this step depends on
      */
     @Nullable
-    public List<String> getArrayOfDependsOnIds(){
-        return arrayOfDependsOnIds;
+    public HashSet<String> getDependsOnIds(){
+        return dependsOnIds;
     }
 }

--- a/src/main/java/com/microsoft/graph/content/MSBatchResponseContent.java
+++ b/src/main/java/com/microsoft/graph/content/MSBatchResponseContent.java
@@ -48,10 +48,10 @@ public class MSBatchResponseContent {
      * @param batchRequestData the batch request payload data as a JSON string
      * @param batchResponseData the batch response body as a JSON string
      */
-    protected MSBatchResponseContent(@Nonnull final String baseUrl, @Nonnull final String batchRequestData, @Nonnull final String batchResponseData) {
+    protected MSBatchResponseContent(@Nonnull final String baseUrl, @Nonnull final JsonObject batchRequestData, @Nonnull final JsonObject batchResponseData) {
         this.protocol = Protocol.HTTP_1_1;
         this.message = "OK";
-        final Map<String, Request> requestMap = createBatchRequestsHashMap(baseUrl, JsonParser.parseString(batchRequestData).getAsJsonObject());
+        final Map<String, Request> requestMap = createBatchRequestsHashMap(baseUrl, batchRequestData);
         if (requestMap != null)
             batchRequestsHashMap.putAll(requestMap);
         updateFromResponseBody(batchResponseData);
@@ -168,17 +168,15 @@ public class MSBatchResponseContent {
             try {
                 final String batchResponseData = batchResponse.body().string();
                 if (batchResponseData != null) {
-                    updateFromResponseBody(batchResponseData);
+                    updateFromResponseBody(stringToJSONObject(batchResponseData));
                 }
             } catch (final IOException e) {
                 e.printStackTrace();
             }
         }
     }
-    private void updateFromResponseBody(@Nonnull final String batchResponseData) {
-        final JsonObject batchResponseObj = stringToJSONObject(batchResponseData);
+    private void updateFromResponseBody(@Nonnull final JsonObject batchResponseObj) {
         if (batchResponseObj != null) {
-
             final JsonElement nextLinkElement = batchResponseObj.get("@odata.nextLink");
             if (nextLinkElement != null && nextLinkElement.isJsonPrimitive())
                 nextLink = nextLinkElement.getAsString();

--- a/src/main/java/com/microsoft/graph/content/MSBatchResponseContent.java
+++ b/src/main/java/com/microsoft/graph/content/MSBatchResponseContent.java
@@ -99,7 +99,7 @@ public class MSBatchResponseContent {
                         final JsonObject JsonObject = jsonBodyElement.getAsJsonObject();
                         final String bodyAsString = JsonObject.toString();
                         final ResponseBody responseBody = ResponseBody
-                                .create(MediaType.parse("application/json; charset=utf-8"), bodyAsString);
+                                .create(bodyAsString, MediaType.parse("application/json; charset=utf-8"));
                         builder.body(responseBody);
                     }
 
@@ -212,8 +212,7 @@ public class MSBatchResponseContent {
             return null;
         }
     }
-    @Nullable
-    protected Map<String, Request> createBatchRequestsHashMap(@Nonnull final String baseUrl, @Nonnull final JsonObject requestJSONObject) {
+    private Map<String, Request> createBatchRequestsHashMap(@Nonnull final String baseUrl, @Nonnull final JsonObject requestJSONObject) {
         if(baseUrl == null || baseUrl == "" || requestJSONObject == null) {
             return null;
         }
@@ -255,7 +254,7 @@ public class MSBatchResponseContent {
                         final JsonObject JsonObject = jsonBodyElement.getAsJsonObject();
                         final String bodyAsString = JsonObject.toString();
                         final RequestBody requestBody = RequestBody
-                                .create(MediaType.parse("application/json; charset=utf-8"), bodyAsString);
+                                .create(bodyAsString, MediaType.parse("application/json; charset=utf-8"));
                         builder.method(jsonMethodElement.getAsString(), requestBody);
                     } else if (jsonMethodElement != null) {
                         builder.method(jsonMethodElement.getAsString(), null);

--- a/src/main/java/com/microsoft/graph/content/MSBatchResponseContent.java
+++ b/src/main/java/com/microsoft/graph/content/MSBatchResponseContent.java
@@ -42,7 +42,7 @@ public class MSBatchResponseContent {
         this.protocol = batchResponse.protocol();
     }
     /**
-     * intantiates a new response
+     * instantiates a new response
      * internal only, used when the content executes the requests
      * @param baseUrl the base service URL without a trailing slash
      * @param batchRequestData the batch request payload data as a JSON string

--- a/src/main/java/com/microsoft/graph/core/BaseClient.java
+++ b/src/main/java/com/microsoft/graph/core/BaseClient.java
@@ -22,7 +22,7 @@
 
 package com.microsoft.graph.core;
 
-import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
 import com.microsoft.graph.http.CoreHttpProvider;
 import com.microsoft.graph.http.IHttpProvider;
 import com.microsoft.graph.httpcore.HttpClients;
@@ -94,9 +94,9 @@ public class BaseClient implements IBaseClient {
 	 * @return the instance of this builder
 	 */
 	@Nonnull
-	public CustomRequestBuilder<JsonObject> customRequest(@Nonnull final String url) {
-		return new CustomRequestBuilder<JsonObject>(getServiceRoot() + url, this, null,
-				JsonObject.class);
+	public CustomRequestBuilder<JsonElement> customRequest(@Nonnull final String url) {
+		return new CustomRequestBuilder<JsonElement>(getServiceRoot() + url, this, null,
+				JsonElement.class);
 	}
 
 	/**

--- a/src/main/java/com/microsoft/graph/core/IBaseClient.java
+++ b/src/main/java/com/microsoft/graph/core/IBaseClient.java
@@ -25,7 +25,7 @@ package com.microsoft.graph.core;
 import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
-import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
 import com.microsoft.graph.http.IHttpProvider;
 import com.microsoft.graph.logger.ILogger;
 import com.microsoft.graph.serializer.ISerializer;
@@ -91,7 +91,7 @@ public interface IBaseClient {
      * @param url the url to send the request to
      */
     @Nonnull
-    CustomRequestBuilder<JsonObject> customRequest(@Nonnull final String url);
+    CustomRequestBuilder<JsonElement> customRequest(@Nonnull final String url);
 
     /**
      * Gets the service SDK version if the service SDK is in use, null otherwise

--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -207,9 +207,6 @@ public class DefaultSerializer implements ISerializer {
 	@Nullable
 	public <T> String serializeObject(@Nonnull final T serializableObject) {
         logger.logDebug("Serializing type " + serializableObject.getClass().getSimpleName());
-        if(serializableObject instanceof String) { // we don't want to over serialize if we already have a serialized string
-            return (String)serializableObject;
-        }
 		JsonElement outJsonTree = gson.toJsonTree(serializableObject);
 
 		if (serializableObject instanceof IJsonBackedObject) {

--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -206,7 +206,10 @@ public class DefaultSerializer implements ISerializer {
 	@Override
 	@Nullable
 	public <T> String serializeObject(@Nonnull final T serializableObject) {
-		logger.logDebug("Serializing type " + serializableObject.getClass().getSimpleName());
+        logger.logDebug("Serializing type " + serializableObject.getClass().getSimpleName());
+        if(serializableObject instanceof String) { // we don't want to over serialize if we already have a serialized string
+            return (String)serializableObject;
+        }
 		JsonElement outJsonTree = gson.toJsonTree(serializableObject);
 
 		if (serializableObject instanceof IJsonBackedObject) {

--- a/src/test/java/com/microsoft/graph/content/MSBatchRequestContentTest.java
+++ b/src/test/java/com/microsoft/graph/content/MSBatchRequestContentTest.java
@@ -2,17 +2,13 @@ package com.microsoft.graph.content;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.google.gson.JsonParser;
@@ -28,7 +24,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import okhttp3.Call;
-import okhttp3.Callback;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
@@ -115,34 +110,26 @@ public class MSBatchRequestContentTest {
             }
         });
 
-        try {
+        assertThrows("the number of steps cannot exceed 20", IllegalArgumentException.class, () -> {
             new MSBatchRequestContent(null, null, null, null, null, null, null, null, null, null, null, null, null,
                     null, null, null, null, null, null, null, null, null);
-            fail("the number of steps cannot exceed 20");
-        } catch (IllegalArgumentException ex) {
-        }
+        });
 
         new MSBatchRequestContent(mockStep, null); // addind a null step doesn't throw
-        try {
+        assertThrows("should throw argument exception", IllegalArgumentException.class, () -> {
             new MSBatchRequestContent().addBatchRequestStep(null);
-            fail("should throw argument exception");
-        } catch (IllegalArgumentException ex) {
-        }
-        try {
+        });
+        assertThrows("should throw argument exception", IllegalArgumentException.class, () -> {
             new MSBatchRequestContent().addBatchRequestStep((Request) null);
-            fail("should throw argument exception");
-        } catch (IllegalArgumentException ex) {
-        }
+        });
 
-        try {
+        assertThrows("the number of steps cannot exceed 20", IllegalArgumentException.class, () -> {
             final MSBatchRequestContent batchContent = new MSBatchRequestContent();
             for (int i = 0; i < MSBatchRequestContent.MAX_NUMBER_OF_REQUESTS; i++) {
                 assertNotNull(batchContent.addBatchRequestStep(mock(Request.class)));
             }
             batchContent.addBatchRequestStep(mock(Request.class));
-            fail("the number of steps cannot exceed 20");
-        } catch (IllegalArgumentException ex) {
-        }
+        });
         {
             final MSBatchRequestContent batchContent = new MSBatchRequestContent();
             reservedIds.clear();

--- a/src/test/java/com/microsoft/graph/content/MSBatchRequestContentTest.java
+++ b/src/test/java/com/microsoft/graph/content/MSBatchRequestContentTest.java
@@ -1,13 +1,40 @@
 package com.microsoft.graph.content;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.google.gson.JsonParser;
+import com.microsoft.graph.authentication.IAuthenticationProvider;
+import com.microsoft.graph.core.BaseClient;
+import com.microsoft.graph.core.IBaseClient;
+import com.microsoft.graph.http.CoreHttpProvider;
+import com.microsoft.graph.logger.ILogger;
+import com.microsoft.graph.serializer.DefaultSerializer;
 
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 public class MSBatchRequestContentTest {
 
@@ -15,22 +42,19 @@ public class MSBatchRequestContentTest {
 
     @Test
     public void testMSBatchRequestContentCreation() {
-        List<MSBatchRequestStep> requestStepArray = new ArrayList<>();
-        for(int i=0;i<5;i++) {
+        MSBatchRequestContent requestContent = new MSBatchRequestContent();
+        for (int i = 0; i < 5; i++) {
             Request request = new Request.Builder().url(testurl).build();
-            List<String> arrayOfDependsOnIds = new ArrayList<>();
-            MSBatchRequestStep requestStep = new MSBatchRequestStep("" + i, request, arrayOfDependsOnIds);
-            requestStepArray.add(requestStep);
+            MSBatchRequestStep requestStep = new MSBatchRequestStep("" + i, request);
+            requestContent.addBatchRequestStep(requestStep);
         }
-        MSBatchRequestContent requestContent = new MSBatchRequestContent(requestStepArray);
         assertTrue(requestContent.getBatchRequestContent() != null);
     }
 
     @Test
     public void testGetBatchRequestContent() {
         Request request = new Request.Builder().url(testurl).build();
-        List<String> arrayOfDependsOnIds = new ArrayList<>();
-        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request, arrayOfDependsOnIds);
+        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request);
         MSBatchRequestContent requestContent = new MSBatchRequestContent();
         requestContent.addBatchRequestStep(requestStep);
         String content = requestContent.getBatchRequestContent();
@@ -41,8 +65,7 @@ public class MSBatchRequestContentTest {
     @Test
     public void testGetBatchRequestContentWithHeader() {
         Request request = new Request.Builder().url(testurl).header("testkey", "testvalue").build();
-        List<String> arrayOfDependsOnIds = new ArrayList<>();
-        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request, arrayOfDependsOnIds);
+        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request);
         MSBatchRequestContent requestContent = new MSBatchRequestContent();
         requestContent.addBatchRequestStep(requestStep);
         String content = requestContent.getBatchRequestContent();
@@ -54,8 +77,7 @@ public class MSBatchRequestContentTest {
     @Test
     public void testRemoveBatchRequesStepWithId() {
         Request request = new Request.Builder().url(testurl).build();
-        List<String> arrayOfDependsOnIds = new ArrayList<>();
-        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request, arrayOfDependsOnIds);
+        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request);
         MSBatchRequestContent requestContent = new MSBatchRequestContent();
         requestContent.addBatchRequestStep(requestStep);
         requestContent.removeBatchRequestStepWithId("1");
@@ -67,13 +89,10 @@ public class MSBatchRequestContentTest {
     @Test
     public void testRemoveBatchRequesStepWithIdByAddingMultipleBatchSteps() {
         Request request = new Request.Builder().url(testurl).build();
-        List<String> arrayOfDependsOnIds = new ArrayList<>();
-        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request, arrayOfDependsOnIds);
+        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request);
 
         Request request1 = new Request.Builder().url(testurl).build();
-        List<String> arrayOfDependsOnIds1 = new ArrayList<>();
-        arrayOfDependsOnIds1.add("1");
-        MSBatchRequestStep requestStep1 = new MSBatchRequestStep("2", request1, arrayOfDependsOnIds1);
+        MSBatchRequestStep requestStep1 = new MSBatchRequestStep("2", request1, "1");
 
         MSBatchRequestContent requestContent = new MSBatchRequestContent();
         requestContent.addBatchRequestStep(requestStep);
@@ -85,4 +104,109 @@ public class MSBatchRequestContentTest {
         assertTrue(content.compareTo(expectedContent) == 0);
     }
 
+    @Test
+    public void defensiveProgrammingTests() {
+        final MSBatchRequestStep mockStep = mock(MSBatchRequestStep.class);
+        final HashSet<String> reservedIds = new HashSet<>();
+        when(mockStep.getRequestId()).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return getNewId(reservedIds);
+            }
+        });
+
+        try {
+            new MSBatchRequestContent(null, null, null, null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null);
+            fail("the number of steps cannot exceed 20");
+        } catch (IllegalArgumentException ex) {
+        }
+
+        new MSBatchRequestContent(mockStep, null); // addind a null step doesn't throw
+        try {
+            new MSBatchRequestContent().addBatchRequestStep(null);
+            fail("should throw argument exception");
+        } catch (IllegalArgumentException ex) {
+        }
+        try {
+            new MSBatchRequestContent().addBatchRequestStep((Request) null);
+            fail("should throw argument exception");
+        } catch (IllegalArgumentException ex) {
+        }
+
+        try {
+            final MSBatchRequestContent batchContent = new MSBatchRequestContent();
+            for (int i = 0; i < MSBatchRequestContent.MAX_NUMBER_OF_REQUESTS; i++) {
+                assertNotNull(batchContent.addBatchRequestStep(mock(Request.class)));
+            }
+            batchContent.addBatchRequestStep(mock(Request.class));
+            fail("the number of steps cannot exceed 20");
+        } catch (IllegalArgumentException ex) {
+        }
+        {
+            final MSBatchRequestContent batchContent = new MSBatchRequestContent();
+            reservedIds.clear();
+            for (int i = 0; i < MSBatchRequestContent.MAX_NUMBER_OF_REQUESTS; i++) {
+                assertTrue("item number " + i + " should be added successfully",
+                        batchContent.addBatchRequestStep(mockStep));
+            }
+            assertFalse(batchContent.addBatchRequestStep(mockStep));
+        }
+    }
+
+    private String getNewId(final HashSet<String> reserved) {
+        String requestId;
+        do {
+            requestId = Integer.toString(ThreadLocalRandom.current().nextInt(1, Integer.MAX_VALUE));
+        } while (reserved.contains(requestId));
+        reserved.add(requestId);
+        return requestId;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void executeBatchTest() throws Throwable {
+        final MSBatchRequestStep step = new MSBatchRequestStep("1", new Request
+                                                                    .Builder()
+                                                                    .url(testurl)
+                                                                    .method("GET", null)
+                                                                    .build());
+        final MSBatchRequestContent content = new MSBatchRequestContent(step);
+        final OkHttpClient mHttpClient = mock(OkHttpClient.class);
+        final Call mCall = mock(Call.class);
+        when(mHttpClient.newCall(any(Request.class))).thenReturn(mCall);
+
+        final CoreHttpProvider mHttpProvider = new CoreHttpProvider(new DefaultSerializer(mock(ILogger.class)), mock(ILogger.class), mHttpClient);
+        final IBaseClient mClient = BaseClient.builder()
+                                            .authenticationProvider(mock(IAuthenticationProvider.class))
+                                            .httpProvider(mHttpProvider)
+                                            .buildClient();
+        final Response mResponse = new Response
+                                            .Builder()
+                                            .request(new Request
+                                                        .Builder()
+                                                        .url("https://graph.microsoft.com/v1.0/$batch")
+                                                        .build())
+                                            .code(200)
+                                            .protocol(Protocol.HTTP_1_1)
+                                            .message("OK")
+                                            .addHeader("Content-type", "application/json")
+                                            .body(ResponseBody.create("{\"responses\": [{\"id\": \"1\",\"status\": 200,\"body\": null}]}",
+                                                    MediaType.parse("application/json")))
+                                            .build();
+        when(mCall.execute()).thenReturn(mResponse);
+        final MSBatchResponseContent batchResponse = content.execute(mClient);
+        final Response response = batchResponse.getResponseById("1");
+        assertNotNull(response);
+    }
+    @Test
+    public void responseParsing() {
+        final MSBatchResponseContent batchResponse = new MSBatchResponseContent("https://graph.microsoft.com/v1.0",
+                                                        JsonParser.parseString("{\"requests\":[{\"id\":\"1\",\"method\":\"GET\",\"url\":\"/me\"}]}")
+                                                                    .getAsJsonObject(),
+                                                        JsonParser.parseString("{\"responses\": [{\"id\": \"1\",\"status\": 200,\"body\": null}]}")
+                                                                    .getAsJsonObject());
+        final Response response = batchResponse.getResponseById("1");
+        assertNotNull(response);
+    }
 }

--- a/src/test/java/com/microsoft/graph/content/MSBatchRequestStepTest.java
+++ b/src/test/java/com/microsoft/graph/content/MSBatchRequestStepTest.java
@@ -1,9 +1,8 @@
 package com.microsoft.graph.content;
 
 import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.List;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
@@ -14,12 +13,31 @@ public class MSBatchRequestStepTest {
     @Test
     public void testMSBatchRequestStepCreation() {
         Request request = new Request.Builder().url("http://graph.microsoft.com").build();
-        List<String> arrayOfDependsOnIds = new ArrayList<>();
-        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request, arrayOfDependsOnIds);
+        MSBatchRequestStep requestStep = new MSBatchRequestStep("1", request);
         assertTrue("Test BatchRequestStep creation", requestStep != null);
         assertTrue("Test Request id", requestStep.getRequestId().compareTo("1") == 0);
         assertTrue("Test Request object", requestStep.getRequest() == request);
-        assertTrue("Test Array of depends on Ids", requestStep.getArrayOfDependsOnIds() != null);
+        assertTrue("Test Array of depends on Ids", requestStep.getDependsOnIds() != null);
+    }
+
+    @Test
+    public void defensiveProgrammingTests() {
+        try {
+            new MSBatchRequestStep(null, null);
+            fail("should throw argument exception");
+        } catch (IllegalArgumentException ex) {
+        }
+        try {
+            new MSBatchRequestStep("id", null);
+            fail("should throw argument exception");
+        } catch (IllegalArgumentException ex) {
+        }
+        try {
+            new MSBatchRequestStep("", null);
+            fail("should throw argument exception");
+        } catch (IllegalArgumentException ex) {
+        }
+        new MSBatchRequestStep("id", mock(Request.class));
     }
 
 }

--- a/src/test/java/com/microsoft/graph/content/MSBatchRequestStepTest.java
+++ b/src/test/java/com/microsoft/graph/content/MSBatchRequestStepTest.java
@@ -1,7 +1,7 @@
 package com.microsoft.graph.content;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
@@ -22,21 +22,15 @@ public class MSBatchRequestStepTest {
 
     @Test
     public void defensiveProgrammingTests() {
-        try {
+        assertThrows("should throw argument exception", IllegalArgumentException.class, () -> {
             new MSBatchRequestStep(null, null);
-            fail("should throw argument exception");
-        } catch (IllegalArgumentException ex) {
-        }
-        try {
+        });
+        assertThrows("should throw argument exception", IllegalArgumentException.class, () -> {
             new MSBatchRequestStep("id", null);
-            fail("should throw argument exception");
-        } catch (IllegalArgumentException ex) {
-        }
-        try {
+        });
+        assertThrows("should throw argument exception", IllegalArgumentException.class, () -> {
             new MSBatchRequestStep("", null);
-            fail("should throw argument exception");
-        } catch (IllegalArgumentException ex) {
-        }
+        });
         new MSBatchRequestStep("id", mock(Request.class));
     }
 

--- a/src/test/java/com/microsoft/graph/content/MSBatchResponseContentTest.java
+++ b/src/test/java/com/microsoft/graph/content/MSBatchResponseContentTest.java
@@ -1,6 +1,6 @@
 package com.microsoft.graph.content;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -20,13 +20,9 @@ public class MSBatchResponseContentTest {
 
     @Test
     public void testNullMSBatchResponseContent() {
-        Response response = null;
-        try {
-            new MSBatchResponseContent(response);
-        }
-        catch(IllegalArgumentException e) {
-            assertNotNull(e);
-        }
+        assertThrows("should throw argument exception", IllegalArgumentException.class, () -> {
+            new MSBatchResponseContent((Response)null);
+        });
     }
 
     @Test
@@ -49,11 +45,9 @@ public class MSBatchResponseContentTest {
 
     @Test
     public void testInvalidMSBatchResponseContentWithNullResponseString() {
-        try{
+        assertThrows("should throw argument exception", IllegalArgumentException.class, () -> {
             new MSBatchResponseContent(null);
-        }catch(Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-        }
+        });
     }
 
     @Test

--- a/src/test/java/com/microsoft/graph/core/BaseClientTests.java
+++ b/src/test/java/com/microsoft/graph/core/BaseClientTests.java
@@ -95,7 +95,7 @@ public class BaseClientTests {
         final CustomRequest<String> abs = stringRequestBuilder.buildRequest();
         abs.setHttpMethod(HttpMethod.POST);
         final Request nat = abs.getHttpRequest("somestring");
-        assertEquals("somestring", getStringFromRequestBody(nat));
+        assertEquals("\"somestring\"", getStringFromRequestBody(nat));
         assertEquals("application", nat.body().contentType().type());
         assertEquals("json", nat.body().contentType().subtype());
     }

--- a/src/test/java/com/microsoft/graph/core/BaseClientTests.java
+++ b/src/test/java/com/microsoft/graph/core/BaseClientTests.java
@@ -1,6 +1,13 @@
 package com.microsoft.graph.core;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -10,11 +17,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okio.BufferedSink;
+import okio.Okio;
 
 import com.microsoft.graph.http.IHttpProvider;
-import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
 import com.microsoft.graph.http.CoreHttpProvider;
+import com.microsoft.graph.http.CustomRequest;
+import com.microsoft.graph.http.HttpMethod;
 import com.microsoft.graph.logger.ILogger;
+import com.microsoft.graph.serializer.DefaultSerializer;
 import com.microsoft.graph.serializer.ISerializer;
 
 /**
@@ -74,9 +87,28 @@ public class BaseClientTests {
     }
     @Test
     public void testCustomRequest() {
-        final CustomRequestBuilder<JsonObject> simpleRequest = baseClient.customRequest("");
-        assertNotNull(simpleRequest);
-        final CustomRequestBuilder<String> stringRequest = baseClient.customRequest("", String.class);
-        assertNotNull(stringRequest);
+        baseClient.setHttpProvider(new CoreHttpProvider(new DefaultSerializer(mLogger), mLogger, new OkHttpClient.Builder().build()));
+        final CustomRequestBuilder<JsonElement> simpleRequestBuilder = baseClient.customRequest("");
+        assertNotNull(simpleRequestBuilder);
+        final CustomRequestBuilder<String> stringRequestBuilder = baseClient.customRequest("", String.class);
+        assertNotNull(stringRequestBuilder);
+        final CustomRequest<String> abs = stringRequestBuilder.buildRequest();
+        abs.setHttpMethod(HttpMethod.POST);
+        final Request nat = abs.getHttpRequest("somestring");
+        assertEquals("somestring", getStringFromRequestBody(nat));
+        assertEquals("application", nat.body().contentType().type());
+        assertEquals("json", nat.body().contentType().subtype());
+    }
+    private String getStringFromRequestBody(Request request) {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final BufferedSink buffer = Okio.buffer(Okio.sink(out));
+            request.body().writeTo(buffer);
+            ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+            return CoreHttpProvider.streamToString(in);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            return "";
+        }
     }
 }


### PR DESCRIPTION
- adds an execute method for JSON batches to avoid customers juggling with clients
- reverts string serialization bypass to avoid unconsistent behavior
- adds defensive programming - switches to json objects to avoid too much string manipulations - fixes a bug where the service root would be appended twice - adds missing unit tests

This PR not only improves code coverage and reliability of the whole batching implementation, but also makes usage simpler.
https://github.com/microsoftgraph/microsoft-graph-docs/compare/feature/java-sdk-v3?expand=1