### PR TITLE
bugfix/default post content type and primitive types

### DIFF
--- a/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
@@ -268,11 +268,7 @@ public class CoreHttpProvider implements IHttpProvider<Request> {
 			// This ensures that the Content-Length header is properly set
 			if (request.getHttpMethod() == HttpMethod.POST) {
 				bytesToWrite = new byte[0];
-				if(contenttype == null) {
-					contenttype = BINARY_CONTENT_TYPE;
-				}
-			}
-			else {
+			} else {
 				bytesToWrite = null;
 			}
 		} else if (serializable instanceof byte[]) {
@@ -329,7 +325,11 @@ public class CoreHttpProvider implements IHttpProvider<Request> {
 
 				@Override
 				public MediaType contentType() {
-					return MediaType.parse(mediaContentType);
+                    if(mediaContentType == null || mediaContentType.isEmpty()) {
+                        return null;
+                    } else {
+					    return MediaType.parse(mediaContentType);
+                    }
 				}
 			};
 		}

--- a/src/main/java/com/microsoft/graph/serializer/EdmNativeTypeSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/EdmNativeTypeSerializer.java
@@ -1,0 +1,60 @@
+package com.microsoft.graph.serializer;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.microsoft.graph.logger.ILogger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Deserializer for native EDM types from the service. Used for actions and functions that return native types for example. */
+public class EdmNativeTypeSerializer {
+    /**
+     * Deserializes native EDM types from the service. Used for actions and functions that return native types for example.
+     * @param <T> Expected return type.
+     * @param json json to deserialize.
+     * @param type class of the expected return type.
+     * @param logger logger to use.
+     * @return the deserialized type or null.
+     */
+    @Nullable
+    public static <T> T deserialize(@Nonnull final JsonElement json, @Nonnull final Class<T> type, @Nonnull final ILogger logger) {
+        if (json == null || type == null) {
+			return null;
+        } else if(json.isJsonPrimitive()) {
+            return getPrimitiveValue(json, type);
+		} else if(json.isJsonObject()) {
+            final JsonElement element = json.getAsJsonObject().get("@odata.null");
+            if(element != null && element.isJsonPrimitive()) {
+                return getPrimitiveValue(element, type);
+            } else {
+                return null;
+            }
+        }
+        return null;
+    }
+    @SuppressWarnings("unchecked")
+    private static <T> T getPrimitiveValue(final JsonElement json, final Class<T> type) {
+        if(type == Boolean.class) {
+            return (T) Boolean.valueOf(json.getAsBoolean());
+        } else if(type == String.class) {
+            return (T)json.getAsString();
+        } else if(type == Integer.class) {
+            return (T) Integer.valueOf(json.getAsInt());
+        } else if(type == UUID.class) {
+            return (T) UUID.fromString(json.getAsString());
+        } else if(type == Long.class) {
+            return (T) Long.valueOf(json.getAsLong());
+        } else if (type == Float.class) {
+            return (T) Float.valueOf(json.getAsFloat());
+        } else if (type == BigDecimal.class) {
+            return (T) json.getAsBigDecimal();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/microsoft/graph/serializer/EdmNativeTypeSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/EdmNativeTypeSerializer.java
@@ -24,10 +24,10 @@ public class EdmNativeTypeSerializer {
     @Nullable
     public static <T> T deserialize(@Nonnull final JsonElement json, @Nonnull final Class<T> type, @Nonnull final ILogger logger) {
         if (json == null || type == null) {
-			return null;
+            return null;
         } else if(json.isJsonPrimitive()) {
             return getPrimitiveValue(json, type);
-		} else if(json.isJsonObject()) {
+        } else if(json.isJsonObject()) {
             final JsonElement element = json.getAsJsonObject().get("@odata.null");
             if(element != null && element.isJsonPrimitive()) {
                 return getPrimitiveValue(element, type);

--- a/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
+++ b/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
@@ -38,11 +38,13 @@ import com.microsoft.graph.core.DateOnly;
 
 import com.microsoft.graph.core.TimeOfDay;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.GregorianCalendar;
+import java.util.UUID;
 
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
@@ -254,8 +256,78 @@ final class GsonFactory {
             }
         };
 
+        final JsonDeserializer<Boolean> booleanJsonDeserializer = new JsonDeserializer<Boolean>() {
+            @Override
+            public Boolean deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, Boolean.class, logger);
+            }
+        };
+
+        final JsonDeserializer<String> stringJsonDeserializer = new JsonDeserializer<String>() {
+            @Override
+            public String deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, String.class, logger);
+            }
+        };
+
+        final JsonDeserializer<BigDecimal> bigDecimalJsonDeserializer = new JsonDeserializer<BigDecimal>() {
+            @Override
+            public BigDecimal deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, BigDecimal.class, logger);
+            }
+        };
+
+        final JsonDeserializer<Integer> integerJsonDeserializer = new JsonDeserializer<Integer>() {
+            @Override
+            public Integer deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, Integer.class, logger);
+            }
+        };
+
+        final JsonDeserializer<Long> longJsonDeserializer = new JsonDeserializer<Long>() {
+            @Override
+            public Long deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, Long.class, logger);
+            }
+        };
+
+        final JsonDeserializer<UUID> uuidJsonDeserializer = new JsonDeserializer<UUID>() {
+            @Override
+            public UUID deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, UUID.class, logger);
+            }
+        };
+
+        final JsonDeserializer<Float> floatJsonDeserializer = new JsonDeserializer<Float>() {
+            @Override
+            public Float deserialize(final JsonElement json,
+                    final Type typeOfT,
+                    final JsonDeserializationContext context) throws JsonParseException {
+                    return EdmNativeTypeSerializer.deserialize(json, Float.class, logger);
+            }
+        };
+
         return new GsonBuilder()
                 .excludeFieldsWithoutExposeAnnotation()
+                .registerTypeAdapter(Boolean.class, booleanJsonDeserializer)
+                .registerTypeAdapter(String.class, stringJsonDeserializer)
+                .registerTypeAdapter(Float.class, floatJsonDeserializer)
+                .registerTypeAdapter(Integer.class, integerJsonDeserializer)
+                .registerTypeAdapter(BigDecimal.class, bigDecimalJsonDeserializer)
+                .registerTypeAdapter(UUID.class, uuidJsonDeserializer)
+                .registerTypeAdapter(Long.class, longJsonDeserializer)
                 .registerTypeAdapter(OffsetDateTime.class, calendarJsonSerializer)
                 .registerTypeAdapter(OffsetDateTime.class, calendarJsonDeserializer)
                 .registerTypeAdapter(GregorianCalendar.class, calendarJsonSerializer)

--- a/src/test/java/com/microsoft/graph/serializer/EdmNativeTypeSerializerTests.java
+++ b/src/test/java/com/microsoft/graph/serializer/EdmNativeTypeSerializerTests.java
@@ -1,0 +1,76 @@
+package com.microsoft.graph.serializer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.microsoft.graph.logger.DefaultLogger;
+
+import org.junit.jupiter.api.Test;
+
+public class EdmNativeTypeSerializerTests {
+    @Test
+    public void testBoolean() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":true}";
+        final Boolean result = serializer.deserializeObject(source, Boolean.class);
+
+        assertEquals(Boolean.valueOf(true), result);
+    }
+    @Test
+    public void testInteger() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":12}";
+        final Integer result = serializer.deserializeObject(source, Integer.class);
+
+        assertEquals(Integer.valueOf(12), result);
+    }
+    @Test
+    public void testString() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":\"toto\"}";
+        final String result = serializer.deserializeObject(source, String.class);
+
+        assertEquals("toto", result);
+    }
+    @Test
+    public void testFloat() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":12.5}";
+        final Float result = serializer.deserializeObject(source, Float.class);
+
+        assertEquals(Float.valueOf("12.5"), result);
+    }
+    @Test
+    public void testLong() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":12}";
+        final Long result = serializer.deserializeObject(source, Long.class);
+
+        assertEquals(Long.valueOf(12), result);
+    }
+    @Test
+    public void testBigDecimal() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":12}";
+        final BigDecimal result = serializer.deserializeObject(source, BigDecimal.class);
+
+        assertEquals(BigDecimal.valueOf(12), result);
+    }
+    @Test
+    public void testUUID() throws Exception {
+        final DefaultSerializer serializer = new DefaultSerializer(new DefaultLogger());
+
+        final String source = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Edm.Null\",\"@odata.null\":\"0E6558C3-9640-4385-860A-2A894AC5C246\"}";
+        final UUID result = serializer.deserializeObject(source, UUID.class);
+
+        assertEquals(UUID.fromString("0E6558C3-9640-4385-860A-2A894AC5C246"), result);
+    }
+}


### PR DESCRIPTION
- fixes a bug where native EDM return types would not be deserialized properly
- fixes a bug where the content type for requests with empty bodies would be wrongfully defaulted

reflection of https://github.com/microsoftgraph/msgraph-sdk-java/pull/693