### PR TITLE
hotfix for additional data serialization

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph-core
 mavenMajorVersion    = 2
 mavenMinorVersion    = 0
-mavenPatchVersion    = 5
+mavenPatchVersion    = 6
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     // Include the sdk as a dependency
-    implementation 'com.microsoft.graph:microsoft-graph-core:2.0.5'
+    implementation 'com.microsoft.graph:microsoft-graph-core:2.0.6'
     // This dependency is only needed if you are using the TokenCrendentialAuthProvider
     implementation 'com.azure:azure-identity:1.3.1'
 }
@@ -37,7 +37,7 @@ Add the dependency in `dependencies` in pom.xml
     <!-- Include the sdk as a dependency -->
     <groupId>com.microsoft.graph</groupId>
     <artifactId>microsoft-graph-core</artifactId>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
     <!-- This dependency is only needed if you are using the TokenCrendentialAuthProvider -->
     <groupId>com.azure</groupId>
     <artifactId>azure-identity</artifactId>

--- a/src/main/java/com/microsoft/graph/httpcore/TelemetryHandler.java
+++ b/src/main/java/com/microsoft/graph/httpcore/TelemetryHandler.java
@@ -3,7 +3,6 @@ package com.microsoft.graph.httpcore;
 import java.io.IOException;
 import java.lang.reflect.Field;
 
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 import com.microsoft.graph.httpcore.middlewareoption.TelemetryOptions;
@@ -25,7 +24,7 @@ public class TelemetryHandler implements Interceptor{
     /**
      * Current SDK version
      */
-    public static final String VERSION = "v2.0.5";
+    public static final String VERSION = "v2.0.6";
     /**
      * Verion prefix
      */

--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -22,7 +22,6 @@
 
 package com.microsoft.graph.serializer;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -35,7 +34,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -241,8 +239,9 @@ public class DefaultSerializer implements ISerializer {
         if(outJson == null || serializableObject == null || !outJson.isJsonObject())
             return;
         final JsonObject outJsonObject = outJson.getAsJsonObject();
+        addAdditionalDataFromJsonObjectToJson(serializableObject, outJsonObject);
         // Use reflection to iterate through fields for eligible Graph children
-        for (java.lang.reflect.Field field : serializableObject.getClass().getFields()) {
+        for (Field field : serializableObject.getClass().getFields()) {
             try {
                 final Object fieldObject = field.get(serializableObject);
                 final JsonElement fieldJsonElement = outJsonObject.get(field.getName());
@@ -275,7 +274,7 @@ public class DefaultSerializer implements ISerializer {
                 } else if(fieldJsonElement.isJsonObject()) {
                     // If the object is a valid Graph object, add its additional data
                     final JsonObject fieldJsonObject = fieldJsonElement.getAsJsonObject();
-                    addAdditionalDataFromJsonObjectToJson(fieldObject, fieldJsonObject);
+                    getChildAdditionalData(fieldObject, fieldJsonObject);
                 }
             } catch (IllegalArgumentException | IllegalAccessException e) {
                 logger.logError("Unable to access child fields of " + serializableObject.getClass().getSimpleName(), e);
@@ -294,7 +293,6 @@ public class DefaultSerializer implements ISerializer {
 			final IJsonBackedObject serializableItem = (IJsonBackedObject) item;
 			final AdditionalDataManager itemAdditionalData = serializableItem.additionalDataManager();
 			addAdditionalDataFromManagerToJson(itemAdditionalData, itemJsonObject);
-			getChildAdditionalData(serializableItem, itemJsonObject);
 		}
 	}
 


### PR DESCRIPTION
- fixes #232 a bug where additional data serialization would fail in some cases
- bumps patch version

During my tests with #232 it looks like when I was running the unit tests on the service library, the local reference wasn't working for some reason. So the unit tests were coming back positive even though it was broken.
This emmergency release fixes additional data serialization in some cases where it wouldn't work anymore, namely for the unit tests:

- AdditionalDataTests > testSkipTransientData
- AdditionalDataTests > testSerializeAdditionalDataOnCollections
- AdditionalDataTests > testAddAdditionalData
- AdditionalDataTests > testHashMapChildAnnotationData

Apologies for the mess 🙏