### PR TITLE
fixed serialization problems for mime messages

### DIFF
--- a/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
@@ -296,7 +296,15 @@ public class CoreHttpProvider implements IHttpProvider<Request> {
 			}
 		} else {
 			logger.logDebug("Sending " + serializable.getClass().getName() + " as request body");
-			final String serializeObject = serializer.serializeObject(serializable);
+
+			String serializeObject = null;
+
+			if ("text/plain".equals(contenttype) && serializable instanceof String) {
+				serializeObject = (String)serializable;
+			} else {
+				serializeObject = serializer.serializeObject(serializable);
+			}
+
             if(serializeObject == null) {
                 throw new ClientException("Error during serialization of request body, the result was null", null);
             }

--- a/src/main/java/com/microsoft/graph/serializer/DerivedClassIdentifier.java
+++ b/src/main/java/com/microsoft/graph/serializer/DerivedClassIdentifier.java
@@ -8,12 +8,16 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/** This class provides methods to get the derived class corresponding to the OData type when deserializing payloads. */
 public class DerivedClassIdentifier {
 
     private final static String ODATA_TYPE_KEY = "@odata.type";
 
     private final ILogger logger;
-
+    /**
+     * Creates a new instance of the dereived class identifier.
+     * @param logger The logger to use.
+     */
     public DerivedClassIdentifier(@Nonnull ILogger logger) {
         this.logger = Objects.requireNonNull(logger, "logger parameter cannot be null");;
     }

--- a/src/test/java/com/microsoft/graph/http/CoreHttpProviderTests.java
+++ b/src/test/java/com/microsoft/graph/http/CoreHttpProviderTests.java
@@ -40,6 +40,7 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.RequestBody;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -306,20 +307,22 @@ public class CoreHttpProviderTests {
             new OkHttpClient.Builder().build());
 
         // GIVEN: A "text/plain" request body
-        HeaderOption option = new HeaderOption("Content-Type", "text/plain");
+        final HeaderOption option = new HeaderOption("Content-Type", "text/plain");
         when(absRequest.getHeaders()).thenReturn(Arrays.asList(option));
-        String expectedBody = "Plain String Body";
+        final String expectedBody = "Plain String Body";
 
         //WHEN: getHttpRequest is called
-        Request request = mProvider.getHttpRequest(absRequest, String.class, expectedBody);
+        final Request request = mProvider.getHttpRequest(absRequest, String.class, expectedBody);
 
         // THEN: The serializer must not be called
         verify(serializer, never()).serializeObject(Mockito.any());
 
         // AND: We expect the request body to contain the plain String, not serialized as Json
-        Buffer buffer = new Buffer();
-        request.body().writeTo(buffer);
-        String actualRequestBody = buffer.readUtf8();
+        final Buffer buffer = new Buffer();
+        final RequestBody requestBody = request.body();
+        assertNotNull(requestBody);
+        requestBody.writeTo(buffer);
+        final String actualRequestBody = buffer.readUtf8();
         assertEquals(expectedBody, actualRequestBody);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-sdk-serviceissues/issues/112

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- When sending mime messages (content-type "text/plain"), the library should not enclose the request body with double quotes

### Additional Information
- After applying this patch, we are now getting a 202 - Accepted from the Server when trying to send a mime message
- However, there seems to be a problem on the Server Side, see: https://docs.microsoft.com/en-us/answers/questions/501593/sending-mime-via-graph-results-in-mangled-e-mail.html
