### PR TITLE
Add support to set a setting to serialize null values

### DIFF
--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -65,19 +65,19 @@ public class DefaultSerializer implements ISerializer {
 	 * @param logger the logger
 	 */
 	public DefaultSerializer(@Nonnull final ILogger logger) {
-		this(false, logger);
+		this(logger, false);
 	}
 
 
     /**
      * Creates a DefaultSerializer with an option to enable serializing of the null values.
      *
-     * @param serializeNulls the setting of whether or not to serialize the null values in the JSON object
      * @param logger         the logger
+     * @param serializeNulls the setting of whether or not to serialize the null values in the JSON object
      */
-    public DefaultSerializer(@Nonnull final boolean serializeNulls, @Nonnull final ILogger logger) {
+    public DefaultSerializer(@Nonnull final ILogger logger, @Nonnull final boolean serializeNulls) {
         this.logger = Objects.requireNonNull(logger, "parameter logger cannot be null");
-        this.gson = GsonFactory.getGsonInstance(serializeNulls, logger);
+        this.gson = GsonFactory.getGsonInstance(logger, serializeNulls);
     }
 
 	@Override

--- a/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
+++ b/src/main/java/com/microsoft/graph/serializer/DefaultSerializer.java
@@ -65,9 +65,20 @@ public class DefaultSerializer implements ISerializer {
 	 * @param logger the logger
 	 */
 	public DefaultSerializer(@Nonnull final ILogger logger) {
-		this.logger = Objects.requireNonNull(logger, "parameter logger cannot be null");
-		this.gson = GsonFactory.getGsonInstance(logger);
+		this(false, logger);
 	}
+
+
+    /**
+     * Creates a DefaultSerializer with an option to enable serializing of the null values.
+     *
+     * @param serializeNulls the setting of whether or not to serialize the null values in the JSON object
+     * @param logger         the logger
+     */
+    public DefaultSerializer(@Nonnull final boolean serializeNulls, @Nonnull final ILogger logger) {
+        this.logger = Objects.requireNonNull(logger, "parameter logger cannot be null");
+        this.gson = GsonFactory.getGsonInstance(serializeNulls, logger);
+    }
 
 	@Override
 	@Nullable

--- a/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
+++ b/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
@@ -44,8 +44,10 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.GregorianCalendar;
+import java.util.Objects;
 import java.util.UUID;
 
+import javax.annotation.Nonnull;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 
@@ -68,19 +70,21 @@ final class GsonFactory {
      * @param logger the logger
      * @return the new instance
      */
-    public static Gson getGsonInstance(final ILogger logger) {
-        return getGsonInstance(false, logger);
+    @Nonnull
+    public static Gson getGsonInstance(@Nonnull final ILogger logger) {
+        return getGsonInstance(logger, false);
     }
 
     /**
      * Creates an instance of GSON
      *
-     * @param serializeNulls the setting of whether or not to serialize the null values in the JSON object
      * @param logger         the logger
+     * @param serializeNulls the setting of whether or not to serialize the null values in the JSON object
      * @return the new instance
      */
-    public static Gson getGsonInstance(final boolean serializeNulls, final ILogger logger) {
-
+    @Nonnull
+    public static Gson getGsonInstance(@Nonnull final ILogger logger, final boolean serializeNulls) {
+        Objects.requireNonNull(logger, "parameter logger cannot be null");
         final JsonSerializer<OffsetDateTime> calendarJsonSerializer = new JsonSerializer<OffsetDateTime>() {
             @Override
             public JsonElement serialize(final OffsetDateTime src,
@@ -340,7 +344,7 @@ final class GsonFactory {
         };
 
         GsonBuilder builder = new GsonBuilder();
-        if(serializeNulls) {
+        if (serializeNulls) {
             builder.serializeNulls();
         }
         return builder

--- a/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
+++ b/src/main/java/com/microsoft/graph/serializer/GsonFactory.java
@@ -69,6 +69,17 @@ final class GsonFactory {
      * @return the new instance
      */
     public static Gson getGsonInstance(final ILogger logger) {
+        return getGsonInstance(false, logger);
+    }
+
+    /**
+     * Creates an instance of GSON
+     *
+     * @param serializeNulls the setting of whether or not to serialize the null values in the JSON object
+     * @param logger         the logger
+     * @return the new instance
+     */
+    public static Gson getGsonInstance(final boolean serializeNulls, final ILogger logger) {
 
         final JsonSerializer<OffsetDateTime> calendarJsonSerializer = new JsonSerializer<OffsetDateTime>() {
             @Override
@@ -328,7 +339,11 @@ final class GsonFactory {
             }
         };
 
-        return new GsonBuilder()
+        GsonBuilder builder = new GsonBuilder();
+        if(serializeNulls) {
+            builder.serializeNulls();
+        }
+        return builder
                 .excludeFieldsWithoutExposeAnnotation()
                 .registerTypeAdapter(Boolean.class, booleanJsonDeserializer)
                 .registerTypeAdapter(String.class, stringJsonDeserializer)

--- a/src/test/java/com/microsoft/graph/serializer/DefaultSerializerTest.java
+++ b/src/test/java/com/microsoft/graph/serializer/DefaultSerializerTest.java
@@ -3,6 +3,7 @@ package com.microsoft.graph.serializer;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.microsoft.graph.logger.ILogger;
+import com.microsoft.graph.models.MessageStub;
 import com.microsoft.graph.models.ReactionStub;
 import com.microsoft.graph.models.SubReactionStub1;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ public class DefaultSerializerTest {
     final ILogger logger = mock(ILogger.class);
     Gson gson = GsonFactory.getGsonInstance(logger);
     DefaultSerializer defaultSerializer = new DefaultSerializer(logger);
+    DefaultSerializer defaultNullSerializer = new DefaultSerializer(true, logger);
 
     @Test
     public void testDeserializationOfObjectWithODataTypeProperty() {
@@ -31,6 +33,34 @@ public class DefaultSerializerTest {
         assertTrue(reaction instanceof SubReactionStub1);
         assertEquals("{\"@odata.type\":\"#microsoft.graph.subReactionStub1\"}", reaction.getRawObject());
         Mockito.verify(reaction.additionalDataManager()).setAdditionalData(gson.fromJson(testJsonResponse, JsonElement.class).getAsJsonObject());
+    }
+
+    @Test
+    public void testDefaultSerializerDoesNotIncludeNullValuesByDefault() {
+        // Given
+        final String testJsonResponse =
+            "{\"@odata.type\": \"#microsoft.graph.messageStub\", \"body\": null}";
+
+        // When
+        DefaultSerializer nonNullSerializer = new DefaultSerializer(logger);
+        MessageStub message = nonNullSerializer.deserializeObject(testJsonResponse, MessageStub.class);
+
+        // Then
+        assertEquals("{}", nonNullSerializer.serializeObject(message));
+    }
+
+    @Test
+    public void testDefaultNullSerializerDoesIncludeNullValues() {
+        // Given
+        final String testJsonResponse =
+            "{\"@odata.type\": \"#microsoft.graph.messageStub\",\"body\":null}";
+
+        // When
+        DefaultSerializer nullSerializer = new DefaultSerializer(true, logger);
+        MessageStub message = nullSerializer.deserializeObject(testJsonResponse, MessageStub.class);
+
+        // Then
+        assertEquals("{\"body\":null,\"reaction\":null}", nullSerializer.serializeObject(message));
     }
 
 }

--- a/src/test/java/com/microsoft/graph/serializer/DefaultSerializerTest.java
+++ b/src/test/java/com/microsoft/graph/serializer/DefaultSerializerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -18,7 +19,6 @@ public class DefaultSerializerTest {
     final ILogger logger = mock(ILogger.class);
     Gson gson = GsonFactory.getGsonInstance(logger);
     DefaultSerializer defaultSerializer = new DefaultSerializer(logger);
-    DefaultSerializer defaultNullSerializer = new DefaultSerializer(true, logger);
 
     @Test
     public void testDeserializationOfObjectWithODataTypeProperty() {
@@ -42,11 +42,11 @@ public class DefaultSerializerTest {
             "{\"@odata.type\": \"#microsoft.graph.messageStub\", \"body\": null}";
 
         // When
-        DefaultSerializer nonNullSerializer = new DefaultSerializer(logger);
-        MessageStub message = nonNullSerializer.deserializeObject(testJsonResponse, MessageStub.class);
+        final MessageStub message = defaultSerializer.deserializeObject(testJsonResponse, MessageStub.class);
 
         // Then
-        assertEquals("{}", nonNullSerializer.serializeObject(message));
+        assertNotNull(message);
+        assertEquals("{}", defaultSerializer.serializeObject(message));
     }
 
     @Test
@@ -56,10 +56,11 @@ public class DefaultSerializerTest {
             "{\"@odata.type\": \"#microsoft.graph.messageStub\",\"body\":null}";
 
         // When
-        DefaultSerializer nullSerializer = new DefaultSerializer(true, logger);
-        MessageStub message = nullSerializer.deserializeObject(testJsonResponse, MessageStub.class);
+        final DefaultSerializer nullSerializer = new DefaultSerializer(logger, true);
+        final MessageStub message = nullSerializer.deserializeObject(testJsonResponse, MessageStub.class);
 
         // Then
+        assertNotNull(message);
         assertEquals("{\"body\":null,\"reaction\":null}", nullSerializer.serializeObject(message));
     }
 


### PR DESCRIPTION
Fixes #256

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Add constructor in `DefaultSerializer` and `GsonFactory` to set the `.serializeNulls()` option in the `GsonBuilder` to support serializing null values in the serialization output
