### PR TITLE
Update publish-artefacts.yml

### DIFF
--- a/.azure-pipelines/buildAndPackage.yml
+++ b/.azure-pipelines/buildAndPackage.yml
@@ -46,6 +46,9 @@ stages:
       parameters:
         stageID: 'build'
     - template: templates/build/build-and-coverage.yml
+  - job: Publish
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    steps: 
     - template: templates/build/publish-artefacts.yml
 
 - stage: Maven_Preview

--- a/.azure-pipelines/buildAndPackage.yml
+++ b/.azure-pipelines/buildAndPackage.yml
@@ -46,9 +46,6 @@ stages:
       parameters:
         stageID: 'build'
     - template: templates/build/build-and-coverage.yml
-  - job: Publish
-    condition: ne(variables['Build.Reason'], 'PullRequest')
-    steps: 
     - template: templates/build/publish-artefacts.yml
 
 - stage: Maven_Preview

--- a/.azure-pipelines/templates/build/publish-artefacts.yml
+++ b/.azure-pipelines/templates/build/publish-artefacts.yml
@@ -16,6 +16,5 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)/'
 
 - publish: $(Build.ArtifactStagingDirectory)
-  condition: ne(variables['Build.Reason'], 'PullRequest')
   artifact: Drop
   displayName: Publish Build Artifact  

--- a/.azure-pipelines/templates/build/publish-artefacts.yml
+++ b/.azure-pipelines/templates/build/publish-artefacts.yml
@@ -1,6 +1,5 @@
 steps:
 - task: CopyFiles@2
-  condition: ne(variables['Build.Reason'], 'PullRequest')
   inputs:
     SourceFolder: '$(System.DefaultWorkingDirectory)'
     Contents: |

--- a/.azure-pipelines/templates/build/publish-artefacts.yml
+++ b/.azure-pipelines/templates/build/publish-artefacts.yml
@@ -16,5 +16,6 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)/'
 
 - publish: $(Build.ArtifactStagingDirectory)
+  condition: ne(variables['Build.Reason'], 'PullRequest')
   artifact: Drop
   displayName: Publish Build Artifact  

--- a/.azure-pipelines/templates/build/publish-artefacts.yml
+++ b/.azure-pipelines/templates/build/publish-artefacts.yml
@@ -1,5 +1,6 @@
 steps:
 - task: CopyFiles@2
+  condition: ne(variables['Build.Reason'], 'PullRequest')
   inputs:
     SourceFolder: '$(System.DefaultWorkingDirectory)'
     Contents: |
@@ -16,5 +17,6 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)/'
 
 - publish: $(Build.ArtifactStagingDirectory)
+  condition: ne(variables['Build.Reason'], 'PullRequest')
   artifact: Drop
   displayName: Publish Build Artifact  


### PR DESCRIPTION
Publish artifacts when the Build.Reason is not a Pull Request.

<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #289 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Update  the publish artifact conditions such that the Artifacts don't get published when a build is triggered by a PullRequest. 
- CI triggers will still publish the artifacts once changes are pushed to dev/master,  we want this in order to complete the other preview/release stages. 

