### PR TITLE
- adds support for cancelling request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for cancelling requests #361
+
 ### Changed
 
 - Bumps Azure Core from 1.20.0 to 1.22.0 #359, #360, #341, #342

--- a/src/main/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapper.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapper.java
@@ -1,8 +1,11 @@
 package com.microsoft.graph.http;
 
 import java.io.IOException;
-
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nonnull;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -12,6 +15,14 @@ import okhttp3.Response;
  * Wraps the HTTP execution in a future, not public by intention
  */
 class CoreHttpCallbackFutureWrapper implements Callback {
+    public CoreHttpCallbackFutureWrapper(@Nonnull final Call call) {
+        Objects.requireNonNull(call);
+        future.whenComplete((r, ex) -> {
+            if (ex != null && (ex instanceof InterruptedException || ex instanceof CancellationException)) {
+                call.cancel();
+            }
+        });
+    }
     final CompletableFuture<Response> future = new CompletableFuture<>();
 	@Override
 	public void onFailure(Call arg0, IOException arg1) {

--- a/src/main/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapper.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapper.java
@@ -15,6 +15,7 @@ import okhttp3.Response;
  * Wraps the HTTP execution in a future, not public by intention
  */
 class CoreHttpCallbackFutureWrapper implements Callback {
+    final CompletableFuture<Response> future = new CompletableFuture<>();
     public CoreHttpCallbackFutureWrapper(@Nonnull final Call call) {
         Objects.requireNonNull(call);
         future.whenComplete((r, ex) -> {
@@ -23,7 +24,6 @@ class CoreHttpCallbackFutureWrapper implements Callback {
             }
         });
     }
-    final CompletableFuture<Response> future = new CompletableFuture<>();
 	@Override
 	public void onFailure(Call arg0, IOException arg1) {
 		future.completeExceptionally(arg1);

--- a/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
+++ b/src/main/java/com/microsoft/graph/http/CoreHttpProvider.java
@@ -51,6 +51,7 @@ import java.util.Scanner;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import okhttp3.Call;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -375,8 +376,9 @@ public class CoreHttpProvider implements IHttpProvider<Request> {
 			@Nullable final IStatefulResponseHandler<Result, DeserializeType> handler)
 					throws ClientException {
             final Request coreHttpRequest = getHttpRequest(request, resultClass, serializable);
-            final CoreHttpCallbackFutureWrapper wrapper = new CoreHttpCallbackFutureWrapper();
-            corehttpClient.newCall(coreHttpRequest).enqueue(wrapper);
+            final Call call = corehttpClient.newCall(coreHttpRequest);
+            final CoreHttpCallbackFutureWrapper wrapper = new CoreHttpCallbackFutureWrapper(call);
+            call.enqueue(wrapper);
             return wrapper.future.thenApply(r -> processResponse(r, request, resultClass, serializable, handler));
     }
     /**

--- a/src/test/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapperTests.java
+++ b/src/test/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapperTests.java
@@ -1,0 +1,46 @@
+package com.microsoft.graph.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+
+import okhttp3.Call;
+import okhttp3.Response;
+
+public class CoreHttpCallbackFutureWrapperTests {
+
+    @Test
+    public void ThrowsIfCallIsNull() {
+        assertThrows(NullPointerException.class, () -> new CoreHttpCallbackFutureWrapper(null));
+    }
+    boolean isCanceled = false;
+
+    @Test
+    public void CancelsCall() {
+        var call = mock(Call.class);
+        doAnswer(i -> {
+            isCanceled = true;
+            return null;
+        }).when(call).cancel();
+        var wrapper = new CoreHttpCallbackFutureWrapper(call);
+        wrapper.future.cancel(true);
+        assertTrue(isCanceled);
+    }
+
+    @Test
+    public void ReturnsResponseWhenCompleted() throws IOException, InterruptedException, ExecutionException {
+        var call = mock(Call.class);
+        var response = mock(Response.class);
+        var wrapper = new CoreHttpCallbackFutureWrapper(call);
+        wrapper.onResponse(call, response);
+        assertEquals(response, wrapper.future.get());
+    }
+
+}

--- a/src/test/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapperTests.java
+++ b/src/test/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapperTests.java
@@ -17,13 +17,13 @@ import okhttp3.Response;
 public class CoreHttpCallbackFutureWrapperTests {
 
     @Test
-    public void ThrowsIfCallIsNull() {
+    public void throwsIfCallIsNull() {
         assertThrows(NullPointerException.class, () -> new CoreHttpCallbackFutureWrapper(null));
     }
     boolean isCanceled = false;
 
     @Test
-    public void CancelsCall() {
+    public void cancelsCall() {
         var call = mock(Call.class);
         doAnswer(i -> {
             isCanceled = true;
@@ -35,7 +35,7 @@ public class CoreHttpCallbackFutureWrapperTests {
     }
 
     @Test
-    public void ReturnsResponseWhenCompleted() throws IOException, InterruptedException, ExecutionException {
+    public void returnsResponseWhenCompleted() throws IOException, InterruptedException, ExecutionException {
         var call = mock(Call.class);
         var response = mock(Response.class);
         var wrapper = new CoreHttpCallbackFutureWrapper(call);

--- a/src/test/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapperTests.java
+++ b/src/test/java/com/microsoft/graph/http/CoreHttpCallbackFutureWrapperTests.java
@@ -14,16 +14,16 @@ import org.junit.jupiter.api.Test;
 import okhttp3.Call;
 import okhttp3.Response;
 
-public class CoreHttpCallbackFutureWrapperTests {
+class CoreHttpCallbackFutureWrapperTests {
 
     @Test
-    public void throwsIfCallIsNull() {
+    void throwsIfCallIsNull() {
         assertThrows(NullPointerException.class, () -> new CoreHttpCallbackFutureWrapper(null));
     }
     boolean isCanceled = false;
 
     @Test
-    public void cancelsCall() {
+    void cancelsCall() {
         var call = mock(Call.class);
         doAnswer(i -> {
             isCanceled = true;
@@ -35,7 +35,7 @@ public class CoreHttpCallbackFutureWrapperTests {
     }
 
     @Test
-    public void returnsResponseWhenCompleted() throws IOException, InterruptedException, ExecutionException {
+    void returnsResponseWhenCompleted() throws IOException, InterruptedException, ExecutionException {
         var call = mock(Call.class);
         var response = mock(Response.class);
         var wrapper = new CoreHttpCallbackFutureWrapper(call);


### PR DESCRIPTION
Fixes #343

Adds support for cancelling the request

```Java
var  future = graphClient.me().messages().buildRequest().getAsync();
future.cancel(true);
```

Should cancel the outgoing request.

@oprobst88 would you mind giving it a try before we merge it please?

@ramsessanchez would you mind doing some testing as well please? and when this gets merged, could you replicate into kiota http lib?