### PR TITLE
feature/dev to v3 merge

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'adopt'
           java-version: 18
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v2.0.9
+        uses: android-actions/setup-android@v2.0.10
       - name: Add execution right to the script
         run: chmod +x gradlew
         working-directory: ./android

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -105,7 +105,7 @@ jobs:
         run: .\scripts\getLatestVersion.ps1
         shell: pwsh
       - name: Create tag
-        uses: rickstaa/action-create-tag@v1.3.9
+        uses: rickstaa/action-create-tag@v1.5.4
         with:
           tag: ${{ steps.GetVersion.outputs.tag }}
       - name: Queue Git Release

--- a/.github/workflows/git-release.yml
+++ b/.github/workflows/git-release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download Build Artifact
-        uses: dawidd6/action-download-artifact@v2.24.0
+        uses: dawidd6/action-download-artifact@v2.24.3
         with:
           workflow: build-and-publish.yml
           workflow_conclusion: success

--- a/.github/workflows/projectsbot.yml
+++ b/.github/workflows/projectsbot.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
         with:
           app_id: ${{ secrets.GRAPHBOT_APP_ID }}
           private_key: ${{ secrets.GRAPHBOT_APP_PEM }}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,9 +9,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.11.2"
-        classpath "com.android.tools.build:gradle:7.3.1"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.43.0"
+        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.12.2"
+        classpath "com.android.tools.build:gradle:7.4.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.44.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id 'com.github.spotbugs' version '5.0.12'
-    id "org.sonarqube" version "3.4.0.2513"
+    id 'com.github.spotbugs' version '5.0.13'
+    id "org.sonarqube" version "3.5.0.2730"
 }
 
 java {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,18 +1,18 @@
 dependencies {
     // Use JUnit test framework
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
-    testImplementation 'org.mockito:mockito-inline:4.8.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+    testImplementation 'org.mockito:mockito-inline:5.0.0'
 
     compileOnly 'net.jcip:jcip-annotations:1.0'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.3'
 
     implementation 'com.google.guava:guava:31.1-jre'
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10.1'
 
     api 'com.squareup.okhttp3:okhttp:4.10.0'
-    api 'com.azure:azure-core:1.32.0'
+    api 'com.azure:azure-core:1.35.0'
 
     api 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.11-SNAPSHOT'
     api 'com.microsoft.kiota:microsoft-kiota-authentication-azure:0.0.4-SNAPSHOT'

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.1</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -35,25 +35,30 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
-            <version>1.33.0</version>
+            <version>1.35.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.9.1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.8.0</version>
+            <version>5.0.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.7.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/deviceCodeSample/build.gradle
+++ b/samples/deviceCodeSample/build.gradle
@@ -12,5 +12,5 @@ repositories {
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     implementation project(':coreLibrary')
-    implementation 'com.azure:azure-identity:1.6.1'
+    implementation 'com.azure:azure-identity:1.7.3'
 }

--- a/samples/interactiveBrowserSample/build.gradle
+++ b/samples/interactiveBrowserSample/build.gradle
@@ -12,5 +12,5 @@ repositories {
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     implementation project(':coreLibrary')
-    implementation 'com.azure:azure-identity:1.6.1'
+    implementation 'com.azure:azure-identity:1.7.3'
 }


### PR DESCRIPTION
- Bump mockito-inline from 4.8.0 to 4.8.1
- Bump mockito-inline from 4.8.0 to 4.8.1
- Bump mockito-inline from 4.8.0 to 4.8.1 in /android
- Bump com.github.spotbugs from 5.0.12 to 5.0.13
- Bump android-actions/setup-android from 2.0.9 to 2.0.10
- Bump com.github.spotbugs in /samples/interactiveBrowserSample
- Bump com.github.spotbugs in /samples/deviceCodeSample
- Bump gson from 2.9.1 to 2.10
- Bump gson from 2.9.1 to 2.10
- Bump gson from 2.9.1 to 2.10 in /android
- Bump org.sonarqube from 3.4.0.2513 to 3.5.0.2730
- Bump org.sonarqube in /samples/deviceCodeSample
- Bump org.sonarqube in /samples/interactiveBrowserSample
- Bump gradle-enterprise-gradle-plugin from 3.11.2 to 3.11.3 in /android
- Bump azure-core from 1.33.0 to 1.34.0
- Bump azure-core from 1.33.0 to 1.34.0
- Bump azure-identity in /samples/interactiveBrowserSample
- Bump azure-core from 1.33.0 to 1.34.0 in /android
- Bump azure-identity from 1.6.1 to 1.7.0 in /samples/deviceCodeSample
- Bump dawidd6/action-download-artifact from 2.24.0 to 2.24.1
- Bump gradle-enterprise-gradle-plugin from 3.11.3 to 3.11.4 in /android
- Bump dawidd6/action-download-artifact from 2.24.1 to 2.24.2
- Bump gradle-versions-plugin from 0.43.0 to 0.44.0 in /android
- Bump mockito-inline from 4.8.1 to 4.9.0
- Bump mockito-inline from 4.8.1 to 4.9.0
- Bump mockito-inline from 4.8.1 to 4.9.0 in /android
- Bump rickstaa/action-create-tag from 1.3.9 to 1.3.10
- Bump azure-identity from 1.7.0 to 1.7.1 in /samples/deviceCodeSample
- Bump azure-identity in /samples/interactiveBrowserSample
- Bump rickstaa/action-create-tag from 1.3.10 to 1.5.0
- Update codeql-analysis.yml
- Bump tibdex/github-app-token from 1.6.0 to 1.7.0
- Bump gradle-enterprise-gradle-plugin from 3.11.4 to 3.12 in /android
- Bump azure-identity from 1.7.1 to 1.7.2 in /samples/deviceCodeSample
- Bump azure-identity in /samples/interactiveBrowserSample
- Bump mockito-inline from 4.9.0 to 4.10.0
- Bump mockito-inline from 4.9.0 to 4.10.0
- Bump mockito-inline from 4.9.0 to 4.10.0 in /android
- Bump gradle-enterprise-gradle-plugin from 3.12 to 3.12.1 in /android
- Bump mockito-inline from 4.10.0 to 4.11.0
- Bump mockito-inline from 4.10.0 to 4.11.0
- Bump mockito-inline from 4.10.0 to 4.11.0 in /android
- Bump dawidd6/action-download-artifact from 2.24.2 to 2.24.3
- Bump gradle-enterprise-gradle-plugin from 3.12.1 to 3.12.2 in /android
- - adds missing dependency to fix docs refresh CI
- - aligns dependencies
- - typo fix
- Bump azure-core from 1.34.0 to 1.35.0
- Bump spotbugs-annotations from 4.7.2 to 4.7.3
- Bump azure-core from 1.34.0 to 1.35.0
- Bump azure-core from 1.34.0 to 1.35.0 in /android
- Bump gson from 2.10 to 2.10.1
- Bump gson from 2.10 to 2.10.1
- Bump azure-identity from 1.7.2 to 1.7.3 in /samples/deviceCodeSample
- Bump azure-identity in /samples/interactiveBrowserSample
- Bump gson from 2.10 to 2.10.1 in /android
- Bump rickstaa/action-create-tag from 1.5.0 to 1.5.4
- Bump junit-jupiter-params from 5.9.1 to 5.9.2
- Bump junit-jupiter-api from 5.9.1 to 5.9.2
- Bump junit-jupiter-params from 5.9.1 to 5.9.2 in /android
- Bump junit-jupiter-engine from 5.9.1 to 5.9.2
- Bump junit-jupiter-api from 5.9.1 to 5.9.2
- Bump junit-jupiter-api from 5.9.1 to 5.9.2 in /android
- Bump junit-jupiter-engine from 5.9.1 to 5.9.2 in /android
- Bump gradle from 7.3.1 to 7.4.0 in /android
- Bump mockito-inline from 4.11.0 to 5.0.0
- Bump mockito-inline from 4.11.0 to 5.0.0
- Bump mockito-inline from 4.11.0 to 5.0.0 in /android
