### PR TITLE
Change default timeout to align with other sdk languages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [2.0.17] - 2023-03-20
+
 ### Changed
 
+- Aligns default http client timeout to be 100 seconds
 - Fixes NullPointerException in GraphErrorResponse#copy
 
 ## [2.0.16] - 2023-01-30

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph-core
 mavenMajorVersion    = 2
 mavenMinorVersion    = 0
-mavenPatchVersion    = 16
+mavenPatchVersion    = 17
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/src/main/java/com/microsoft/graph/httpcore/HttpClients.java
+++ b/src/main/java/com/microsoft/graph/httpcore/HttpClients.java
@@ -7,6 +7,7 @@ import okhttp3.OkHttpClient.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.Duration;
 import java.util.Objects;
 
 /**
@@ -28,7 +29,10 @@ public class HttpClients {
         return new OkHttpClient.Builder()
                     .addInterceptor(new TelemetryHandler())
                     .followRedirects(false)
-                    .followSslRedirects(false);
+                    .followSslRedirects(false)
+                    .connectTimeout(Duration.ofSeconds(100))
+                    .readTimeout(Duration.ofSeconds(100))
+                    .callTimeout(Duration.ofSeconds(100));
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1381

Related to https://github.com/microsoftgraph/msgraph-sdk-java/issues/1288

`OKHttp` initializes the client with a default timeout of 10 seconds. This aligns the timeout value with other sdks to 100 seconds to reduce possibilities of timeout errors on the client. 