### PR TITLE
Telemetry formatting adjustments

### DIFF
--- a/src/main/java/com/microsoft/graph/CoreConstants.java
+++ b/src/main/java/com/microsoft/graph/CoreConstants.java
@@ -37,6 +37,8 @@ public final class CoreConstants {
         public static final String FEATURE_FLAG = "FeatureFlag";
         /** Default version value constant. */
         public static final String DEFAULT_VERSION_VALUE = "0";
+        /** runtimeEnvironment string format */
+        public static final String RUNTIME_ENV_HEADER_FORMAT = "runtimeEnvironment=JRE/%s";
 
         /**The following appear in dotnet core, are they necessary in Java?
          * Content-Type header:

--- a/src/main/java/com/microsoft/graph/requests/middleware/GraphTelemetryHandler.java
+++ b/src/main/java/com/microsoft/graph/requests/middleware/GraphTelemetryHandler.java
@@ -2,6 +2,7 @@ package com.microsoft.graph.requests.middleware;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Locale;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -43,16 +44,16 @@ public class GraphTelemetryHandler implements Interceptor{
         final Request request = chain.request();
         final Request.Builder telemetryAddedBuilder = request.newBuilder();
 
-        final String graphEndpoint = mGraphClientOption.getGraphServiceTargetVersion();
-        final String featureUsage = "(featureUsage=" + mGraphClientOption.featureTracker.getSerializedFeatureUsage() + ")";
+        final String clientLibraryUsed = "graph-java" + (mGraphClientOption.getGraphServiceTargetVersion().equals("beta") ? "-beta" : "");
+        final String featureUsage = "(featureUsage=" + mGraphClientOption.featureTracker.getSerializedFeatureUsage();
         final String javaVersion = System.getProperty("java.version");
         final String androidVersion = getAndroidAPILevel();
-        final String sdkversion_value = "graph-" + CoreConstants.Headers.JAVA_VERSION_PREFIX +"/"+ graphEndpoint +
+        final String sdkVersion_value = clientLibraryUsed +
             (mGraphClientOption.getClientLibraryVersion() == null ? "" : "/"+ mGraphClientOption.getClientLibraryVersion()) + ", " +
             CoreConstants.Headers.GRAPH_VERSION_PREFIX + "/" + mGraphClientOption.getCoreLibraryVersion() + " " + featureUsage +
-            (CoreConstants.Headers.DEFAULT_VERSION_VALUE.equals(javaVersion) ? "" : (", " + CoreConstants.Headers.JAVA_VERSION_PREFIX + "/" + javaVersion)) +
-            (CoreConstants.Headers.DEFAULT_VERSION_VALUE.equals(androidVersion) ? "" : (", " + CoreConstants.Headers.ANDROID_VERSION_PREFIX + "/" + androidVersion));
-        telemetryAddedBuilder.addHeader(CoreConstants.Headers.SDK_VERSION_HEADER_NAME, sdkversion_value);
+            (CoreConstants.Headers.DEFAULT_VERSION_VALUE.equals(javaVersion) ? ")" : ("; " + String.format(Locale.US,CoreConstants.Headers.RUNTIME_ENV_HEADER_FORMAT,javaVersion))) +
+            (CoreConstants.Headers.DEFAULT_VERSION_VALUE.equals(androidVersion) ? ")" : (": " + CoreConstants.Headers.ANDROID_VERSION_PREFIX + "/" + androidVersion));
+        telemetryAddedBuilder.addHeader(CoreConstants.Headers.SDK_VERSION_HEADER_NAME, sdkVersion_value);
 
         if(request.header(CoreConstants.Headers.CLIENT_REQUEST_ID) == null) {
             telemetryAddedBuilder.addHeader(CoreConstants.Headers.CLIENT_REQUEST_ID, mGraphClientOption.getClientRequestId());

--- a/src/test/java/com/microsoft/graph/requests/middleware/GraphTelemetryHandlerTests.java
+++ b/src/test/java/com/microsoft/graph/requests/middleware/GraphTelemetryHandlerTests.java
@@ -18,13 +18,14 @@ import java.io.IOException;
 
 class GraphTelemetryHandlerTests {
 
+    private String defaultSDKVersion = "graph-java";
+
     public GraphTelemetryHandlerTests() {
     }
 
     @Test
     void telemetryHandlerDefaultTests() throws IOException {
         final String expectedCore = CoreConstants.Headers.GRAPH_VERSION_PREFIX + "/" + CoreConstants.Headers.VERSION;
-        final String expectedClientEndpoint = CoreConstants.Headers.JAVA_VERSION_PREFIX + "/v1.0";
 
         final OkHttpClient client = GraphClientFactory.create().build();
         final Request request = new Request.Builder().url("https://graph.microsoft.com/v1.0/users/").build();
@@ -33,13 +34,12 @@ class GraphTelemetryHandlerTests {
         assertNotNull(response);
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
         assertTrue(!response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(CoreConstants.Headers.ANDROID_VERSION_PREFIX)); // Android version is not going to be present on unit tests running on java platform
-        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedClientEndpoint));
+        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
     }
 
     @Test
     void arrayInterceptorsTest() throws IOException {
         final String expectedCore = CoreConstants.Headers.GRAPH_VERSION_PREFIX + "/" + CoreConstants.Headers.VERSION;
-        final String expectedClientEndpoint = CoreConstants.Headers.JAVA_VERSION_PREFIX + "/v1.0";
 
         final Interceptor[] interceptors = {new GraphTelemetryHandler(), new RetryHandler(), new RedirectHandler()};
         final OkHttpClient client = GraphClientFactory.create(interceptors).build();
@@ -48,13 +48,12 @@ class GraphTelemetryHandlerTests {
 
         assertNotNull(response);
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
-        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedClientEndpoint));
+        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
     }
 
     @Test
     void arrayInterceptorEmptyTest() throws IOException {
         final String expectedCore = CoreConstants.Headers.GRAPH_VERSION_PREFIX + "/" + CoreConstants.Headers.VERSION;
-        final String expectedClientEndpoint = CoreConstants.Headers.JAVA_VERSION_PREFIX + "/v1.0";
 
         final Interceptor[] interceptors = new Interceptor[]{};
         final OkHttpClient client = GraphClientFactory.create(interceptors).build();
@@ -63,7 +62,7 @@ class GraphTelemetryHandlerTests {
 
         assertNotNull(response);
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
-        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedClientEndpoint));
+        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
     }
 
     @Test
@@ -82,7 +81,7 @@ class GraphTelemetryHandlerTests {
         final String expectedCoreVer =
             CoreConstants.Headers.GRAPH_VERSION_PREFIX + "/" +coreLibVer;
         final String expectedClientEndpoint =
-            CoreConstants.Headers.JAVA_VERSION_PREFIX + "/" + serviceLibVer + "/" + clientLibVer;
+            CoreConstants.Headers.JAVA_VERSION_PREFIX + "-" + serviceLibVer + "/" + clientLibVer;
 
         final OkHttpClient client = GraphClientFactory.create(graphClientOption).build();
         final Request request = new Request.Builder().url("https://graph.microsoft.com/v1.0/users/").build();


### PR DESCRIPTION
This branch fixes the telemetry header formatting. 
Whereas a previous telemetry header would have been formatted as: 
SdkVersion: graph-java/v1.0/6.0.0, graph-java-core/3.0.0 (featureUsage=3) java/17.0.3
I have adjusted the formatting to correctly line up with the [spec](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/middleware/TelemetryHandler.md), the same telemetry capture will now be:
SdkVersion: graph-java/6.0.0, graph-java-core/3.0.0 (featureUsage=3; runtimeEnvironment=JRE/17.03)
###Merging into the upload task branch because that branch has important updates to the folder naming conventions which are not present in the current v3/longTermBranch.