### PR TITLE
Update CODEOWNERS with msgraph-devx-java-write

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @baywet @ddyett @MichaelMainer @zengin @ramsessanchez @andrueastman
+* @microsoftgraph/msgraph-devx-java-write


### PR DESCRIPTION
I've removed all individual access grants. All write access now goes through https://github.com/orgs/microsoftgraph/teams/msgraph-devx-java-write team. Please manage code owners through this team.

Admin settings now require JIT admin grant elevation through the Open Source Management Portal.
