### PR TITLE
Enable PageIterator to iterate across all pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [3.1.1] - 2024-02-09
+
+### Changed
+
+- Fixes a bug to allow the PageIterator to iterate across all pages.
+
 ## [3.1.0] - 2024-02-07
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph-core
 mavenMajorVersion    = 3
 mavenMinorVersion    = 1
-mavenPatchVersion    = 0
+mavenPatchVersion    = 1
 mavenArtifactSuffix =
 
 #These values are used to run functional tests

--- a/src/main/java/com/microsoft/graph/core/tasks/PageIterator.java
+++ b/src/main/java/com/microsoft/graph/core/tasks/PageIterator.java
@@ -17,7 +17,7 @@ import java.util.function.UnaryOperator;
 
 /**
  * A class for iterating through pages of a collection
- * Uses to automatically pages through result sets across multiple calls and process each item in the result set.
+ * Use to automatically page through result sets across multiple calls and process each item in the result set.
  * @param <TEntity> The type of the entity returned in the collection. This type must implement {@link Parsable}
  * @param <TCollectionPage> The Microsoft Graph collection response type returned in the collection response. This type must implement {@link Parsable} and {@link AdditionalDataHolder}
  */
@@ -302,16 +302,14 @@ public class PageIterator<TEntity extends Parsable, TCollectionPage extends Pars
     }
     private static <TCollectionPage extends Parsable & AdditionalDataHolder> String extractNextLinkFromParsable(@Nonnull TCollectionPage parsableCollection, @Nullable String getNextLinkMethodName) throws ReflectiveOperationException {
         String methodName = getNextLinkMethodName == null ? CoreConstants.CollectionResponseMethods.GET_ODATA_NEXT_LINK : getNextLinkMethodName;
-        Method[] methods = parsableCollection.getClass().getDeclaredMethods();
+        Method[] methods = parsableCollection.getClass().getMethods();
         String nextLink;
-        if(Arrays.stream(methods).anyMatch(m -> m.getName().equals(methodName))) {
-            try {
-                nextLink = (String) parsableCollection.getClass().getDeclaredMethod(methodName).invoke(parsableCollection);
-                if(!Compatibility.isBlank(nextLink)) {
-                    return nextLink;
-                }
-            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-                throw new ReflectiveOperationException("Could not extract nextLink from parsableCollection.");
+        Optional<Method> nextLinkOptional = Arrays.stream(methods).filter(m -> m.getName().equals(methodName)).findFirst();
+        if (nextLinkOptional.isPresent()) {
+            Method nextLinkMethod = nextLinkOptional.get();
+            nextLink = (String) nextLinkMethod.invoke(parsableCollection);
+            if(!Compatibility.isBlank(nextLink)) {
+                return nextLink;
             }
         }
         nextLink = (String) parsableCollection.getAdditionalData().get(CoreConstants.OdataInstanceAnnotations.NEXT_LINK);

--- a/src/test/java/com/microsoft/graph/core/tasks/PageIteratorTest.java
+++ b/src/test/java/com/microsoft/graph/core/tasks/PageIteratorTest.java
@@ -179,7 +179,7 @@ class PageIteratorTest {
     void given_CollectionPage_Delta_Link_Property_It_Iterates_Across_Pages() throws ReflectiveOperationException, ApiException {
         TestEventsDeltaResponse originalPage = new TestEventsDeltaResponse();
         originalPage.setValue(new LinkedList<>());
-        originalPage.setOdataDeltaLink("http://localhost/events?$skip=11");
+        originalPage.setOdataNextLink("http://localhost/events?$skip=11");
         int inputEventCount = 17;
         for(int i = 0; i < inputEventCount; i++) {
             TestEventItem testEventItem = new TestEventItem();
@@ -187,10 +187,26 @@ class PageIteratorTest {
             originalPage.getValue().add(testEventItem);
         }
 
-        Function<TestEventItem, Boolean> processPageItemCallback = item -> true;
+        TestEventsDeltaResponse secondPage = new TestEventsDeltaResponse();
+        secondPage.setValue(new LinkedList<TestEventItem>());
+        secondPage.setOdataDeltaLink("http://localhost/events?$skip=11");
+        int secondPageEventCount = 5;
+        for(int i = 0; i < secondPageEventCount; i++) {
+            TestEventItem testEventItem = new TestEventItem();
+            testEventItem.setSubject("Second Page Test Event: " + i);
+            secondPage.getValue().add(testEventItem);
+        }
 
+        AtomicInteger totalItemsProcessed = new AtomicInteger(0);
+
+        Function<TestEventItem, Boolean> processPageItemCallback = item -> {
+            totalItemsProcessed.incrementAndGet();
+            return true;
+        };
+
+        MockAdapter mockAdapter = new MockAdapter(mock(AuthenticationProvider.class), secondPage);
         PageIterator<TestEventItem, TestEventsDeltaResponse> pageIterator = new PageIterator.Builder<TestEventItem, TestEventsDeltaResponse>()
-            .client(baseClient)
+            .requestAdapter(mockAdapter)
             .collectionPage(originalPage)
             .collectionPageFactory(TestEventsDeltaResponse::createFromDiscriminatorValue)
             .processPageItemCallback(processPageItemCallback)
@@ -200,6 +216,7 @@ class PageIteratorTest {
 
         assertEquals(PageIterator.PageIteratorState.DELTA, pageIterator.getPageIteratorState());
         assertEquals("http://localhost/events?$skip=11", pageIterator.getDeltaLink());
+        assertEquals(inputEventCount + secondPageEventCount, totalItemsProcessed.get());
     }
 
     @Test

--- a/src/test/java/com/microsoft/graph/core/testModels/BaseCollectionPaginationCountResponse.java
+++ b/src/test/java/com/microsoft/graph/core/testModels/BaseCollectionPaginationCountResponse.java
@@ -1,0 +1,98 @@
+package com.microsoft.graph.core.testModels;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.microsoft.kiota.serialization.AdditionalDataHolder;
+import com.microsoft.kiota.serialization.Parsable;
+import com.microsoft.kiota.serialization.ParseNode;
+import com.microsoft.kiota.serialization.SerializationWriter;
+
+public class BaseCollectionPaginationCountResponse implements AdditionalDataHolder, Parsable {
+    public Map<String, Object> additionalData;
+    private String odataNextLink;
+    private Long odataCount;
+    /**
+     * Instantiates a new BaseCollectionPaginationCountResponse and sets the default values.
+     */
+    public BaseCollectionPaginationCountResponse() {
+        this.setAdditionalData(new HashMap<>());
+    }
+    /**
+     * Creates a new instance of the appropriate class based on discriminator value
+     * @param parseNode The parse node to use to read the discriminator value and create the object
+     * @return a BaseCollectionPaginationCountResponse
+     */
+    @jakarta.annotation.Nonnull
+    public static BaseCollectionPaginationCountResponse createFromDiscriminatorValue(@jakarta.annotation.Nonnull final ParseNode parseNode) {
+        Objects.requireNonNull(parseNode);
+        return new BaseCollectionPaginationCountResponse();
+    }
+    /**
+     * Gets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+     * @return a Map<String, Object>
+     */
+    @jakarta.annotation.Nonnull
+    public Map<String, Object> getAdditionalData() {
+        return this.additionalData;
+    }
+    /**
+     * The deserialization information for the current model
+     * @return a Map<String, java.util.function.Consumer<ParseNode>>
+     */
+    @jakarta.annotation.Nonnull
+    public Map<String, java.util.function.Consumer<ParseNode>> getFieldDeserializers() {
+        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap = new HashMap<String, java.util.function.Consumer<ParseNode>>(2);
+        deserializerMap.put("@odata.count", (n) -> { this.setOdataCount(n.getLongValue()); });
+        deserializerMap.put("@odata.nextLink", (n) -> { this.setOdataNextLink(n.getStringValue()); });
+        return deserializerMap;
+    }
+    /**
+     * Gets the @odata.count property value. The OdataCount property
+     * @return a Long
+     */
+    @jakarta.annotation.Nullable
+    public Long getOdataCount() {
+        return this.odataCount;
+    }
+    /**
+     * Gets the @odata.nextLink property value. The OdataNextLink property
+     * @return a String
+     */
+    @jakarta.annotation.Nullable
+    public String getOdataNextLink() {
+        return this.odataNextLink;
+    }
+    /**
+     * Serializes information the current object
+     * @param writer Serialization writer to use to serialize this model
+     */
+    public void serialize(@jakarta.annotation.Nonnull final SerializationWriter writer) {
+        Objects.requireNonNull(writer);
+        writer.writeLongValue("@odata.count", this.getOdataCount());
+        writer.writeStringValue("@odata.nextLink", this.getOdataNextLink());
+        writer.writeAdditionalData(this.getAdditionalData());
+    }
+    /**
+     * Sets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+     * @param value Value to set for the AdditionalData property.
+     */
+    public void setAdditionalData(@jakarta.annotation.Nullable final Map<String, Object> value) {
+        this.additionalData = value;
+    }
+    /**
+     * Sets the @odata.count property value. The OdataCount property
+     * @param value Value to set for the @odata.count property.
+     */
+    public void setOdataCount(@jakarta.annotation.Nullable final Long value) {
+        this.odataCount = value;
+    }
+    /**
+     * Sets the @odata.nextLink property value. The OdataNextLink property
+     * @param value Value to set for the @odata.nextLink property.
+     */
+    public void setOdataNextLink(@jakarta.annotation.Nullable final String value) {
+        this.odataNextLink = value;
+    }
+}

--- a/src/test/java/com/microsoft/graph/core/testModels/TestEventsDeltaResponse.java
+++ b/src/test/java/com/microsoft/graph/core/testModels/TestEventsDeltaResponse.java
@@ -8,22 +8,12 @@ import com.microsoft.kiota.serialization.SerializationWriter;
 import java.util.*;
 import java.util.function.Consumer;
 
-public class TestEventsDeltaResponse implements Parsable, AdditionalDataHolder {
-    public Map<String, Object> additionalData;
+public class TestEventsDeltaResponse extends BaseCollectionPaginationCountResponse {
     private String odataDeltaLink;
-    private String odataNextLink;
     public List<TestEventItem> value;
 
     public TestEventsDeltaResponse() {
-        additionalData = new HashMap<>();
-    }
-
-    public Map<String, Object> getAdditionalData() {
-        return additionalData;
-    }
-
-    public void setAdditionalData(Map<String, Object> additionalData) {
-        this.additionalData = additionalData;
+        super();
     }
 
     public String getOdataDeltaLink() {
@@ -32,14 +22,6 @@ public class TestEventsDeltaResponse implements Parsable, AdditionalDataHolder {
 
     public void setOdataDeltaLink(String odataDeltaLink) {
         this.odataDeltaLink = odataDeltaLink;
-    }
-
-    public String getOdataNextLink() {
-        return odataNextLink;
-    }
-
-    public void setOdataNextLink(String odataNextLink) {
-        this.odataNextLink = odataNextLink;
     }
 
     public List<TestEventItem> getValue() {
@@ -51,22 +33,15 @@ public class TestEventsDeltaResponse implements Parsable, AdditionalDataHolder {
     }
 
     public Map<String, Consumer<ParseNode>> getFieldDeserializers() {
-        HashMap<String, Consumer<ParseNode>> fieldDeserializers = new HashMap<>();
-        fieldDeserializers.put("@odata.deltaLink", (n) -> setOdataDeltaLink(n.getStringValue()));
-        fieldDeserializers.put("@odata.nextLink", (n) -> setOdataNextLink(n.getStringValue()));
-        fieldDeserializers.put("value", (n) -> setValue(n.getCollectionOfObjectValues(TestEventItem::createFromDiscriminatorValue)));
-        return fieldDeserializers;
+        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap = new HashMap<String, java.util.function.Consumer<ParseNode>>(super.getFieldDeserializers());
+        deserializerMap.put("value", (n) -> { this.setValue(n.getCollectionOfObjectValues(TestEventItem::createFromDiscriminatorValue)); });
+        return deserializerMap;
     }
 
     public void serialize(SerializationWriter writer) {
-        if (writer == null) {
-            throw new IllegalArgumentException("writer");
-        }
-
-        writer.writeStringValue("@odata.deltaLink", odataDeltaLink);
-        writer.writeStringValue("@odata.nextLink", odataNextLink);
-        writer.writeCollectionOfObjectValues("value", value);
-        writer.writeAdditionalData(additionalData);
+        Objects.requireNonNull(writer);
+        super.serialize(writer);
+        writer.writeCollectionOfObjectValues("value", getValue());
     }
 
     public static TestEventsDeltaResponse createFromDiscriminatorValue(ParseNode parseNode) {

--- a/src/test/java/com/microsoft/graph/core/testModels/TestEventsResponse.java
+++ b/src/test/java/com/microsoft/graph/core/testModels/TestEventsResponse.java
@@ -13,30 +13,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-public class TestEventsResponse implements Parsable, AdditionalDataHolder {
-    public Map<String, Object> additionalData;
-    private String odataNextLink;
+public class TestEventsResponse extends BaseCollectionPaginationCountResponse {
     public List<TestEventItem> value;
 
     public TestEventsResponse() {
-        additionalData = new HashMap<>();
-    }
-
-    @Nonnull
-    public Map<String, Object> getAdditionalData() {
-        return additionalData;
-    }
-
-    public void setAdditionalData(Map<String, Object> additionalData) {
-        this.additionalData = additionalData;
-    }
-
-    public String getOdataNextLink() {
-        return odataNextLink;
-    }
-
-    public void setOdataNextLink(String odataNextLink) {
-        this.odataNextLink = odataNextLink;
+        super();
     }
 
     public List<TestEventItem> getValue() {
@@ -48,17 +29,15 @@ public class TestEventsResponse implements Parsable, AdditionalDataHolder {
     }
     @Nonnull
     public Map<String, Consumer<ParseNode>> getFieldDeserializers() {
-        HashMap<String, Consumer<ParseNode>> fieldDeserializers = new HashMap<>();
-        fieldDeserializers.put("@odata.nextLink", (n) -> setOdataNextLink(n.getStringValue()));
-        fieldDeserializers.put("value", (n) -> setValue(n.getCollectionOfObjectValues(TestEventItem::createFromDiscriminatorValue)));
-        return fieldDeserializers;
+        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap = new HashMap<String, java.util.function.Consumer<ParseNode>>(super.getFieldDeserializers());
+        deserializerMap.put("value", (n) -> { this.setValue(n.getCollectionOfObjectValues(TestEventItem::createFromDiscriminatorValue)); });
+        return deserializerMap;
     }
 
     public void serialize(@Nonnull SerializationWriter writer) {
         Objects.requireNonNull(writer);
-        writer.writeStringValue("@odata.nextLink", getOdataNextLink());
+        super.serialize(writer);
         writer.writeCollectionOfObjectValues("value", getValue());
-        writer.writeAdditionalData(getAdditionalData());
     }
 
     public static TestEventsResponse createFromDiscriminatorValue(ParseNode parseNode) {


### PR DESCRIPTION
This PR:
- Fixes a bug in executing the `getOdataNextLink` method on the returned parsableCollection from the API.
- Updates test models to extend a Base class as is the case in the service lib
- Updates test cases to validate number of processed items

closes https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1452