### PR TITLE
Bump version & update CHANGELOG for 3.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [3.1.3] - 2024-02-14
+
+### Changed
+
+- Bumps Kiota-Java abstractions, authentication, http, and serialization components
+
 ## [3.1.2] - 2024-02-12
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph-core
 mavenMajorVersion    = 3
 mavenMinorVersion    = 1
-mavenPatchVersion    = 2
+mavenPatchVersion    = 3
 mavenArtifactSuffix =
 
 #These values are used to run functional tests


### PR DESCRIPTION
Bumps to 3.1.3 to allow developers to use fixes in Kiota [1.0.2](https://github.com/microsoft/kiota-java/releases/tag/v1.0.2)