### PR TITLE
Fix for issue 1517 and correction of two tests not respecting the REST reference (impacted by the fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [3.1.4] - 2024-02-21
+
+- Bumps Kiota-Java abstractions, authentication, http, and serialization components
+- Fixes a test in the test suite which did not respect the REST reference [#1517](https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1517)
+- Fixes a bug with LargeFileUploadTask [#1517](https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1517)
+
+### Changed
+
 ## [3.1.3] - 2024-02-14
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph-core
 mavenMajorVersion    = 3
 mavenMinorVersion    = 1
-mavenPatchVersion    = 3
+mavenPatchVersion    = 4
 mavenArtifactSuffix =
 
 #These values are used to run functional tests

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,11 +16,11 @@ dependencies {
     api 'com.squareup.okhttp3:okhttp:4.12.0'
     api 'com.azure:azure-core:1.46.0'
 
-    api 'com.microsoft.kiota:microsoft-kiota-abstractions:1.0.2'
-    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.0.2'
-    implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.0.2'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.0.2'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.0.2'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.0.2'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.0.2'
+    api 'com.microsoft.kiota:microsoft-kiota-abstractions:1.0.3'
+    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.0.3'
+    implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.0.3'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.0.3'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.0.3'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.0.3'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.0.3'
 }

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     // Include the sdk as a dependency
-    implementation 'com.microsoft.graph:microsoft-graph-core:3.1.3'
+    implementation 'com.microsoft.graph:microsoft-graph-core:3.1.4'
     // This dependency is only needed if you are using the TokenCredentialAuthProvider
     implementation 'com.azure:azure-identity:1.11.0'
 }
@@ -37,7 +37,7 @@ Add the dependency in `dependencies` in pom.xml
     <!-- Include the sdk as a dependency -->
     <groupId>com.microsoft.graph</groupId>
     <artifactId>microsoft-graph-core</artifactId>
-    <version>3.1.3</version>
+    <version>3.1.4</version>
     <!-- This dependency is only needed if you are using the TokenCredentialAuthProvider -->
     <groupId>com.azure</groupId>
     <artifactId>azure-identity</artifactId>

--- a/src/main/java/com/microsoft/graph/core/models/IUploadSession.java
+++ b/src/main/java/com/microsoft/graph/core/models/IUploadSession.java
@@ -29,7 +29,7 @@ public interface IUploadSession extends Parsable, AdditionalDataHolder {
      * A collection of byte ranges that the server is missing for the file. These ranges are zero indexed and of the format 'start-end' (e.g. '0-26' to indicate the first 27 bytes of the file). When uploading files as Outlook attachments, instead of a collection of ranges, this property always indicates a single value '{start}', the location in the file where the next upload should begin.
      * @return the Next Expected Ranges.
      */
-    @Nonnull
+    @Nullable
     List<String> getNextExpectedRanges();
     /**
      * Sets the ranges that are yet to be uploaded.

--- a/src/main/java/com/microsoft/graph/core/models/IUploadSession.java
+++ b/src/main/java/com/microsoft/graph/core/models/IUploadSession.java
@@ -23,7 +23,7 @@ public interface IUploadSession extends Parsable, AdditionalDataHolder {
      * Sets the Upload Url
      * @param url the upload Url for the session
      */
-    void setUploadUrl(@Nonnull String url);
+    void setUploadUrl(@Nonnull final String url);
     /**
      * Gets the Next Expected Ranges.
      * A collection of byte ranges that the server is missing for the file. These ranges are zero indexed and of the format 'start-end' (e.g. '0-26' to indicate the first 27 bytes of the file). When uploading files as Outlook attachments, instead of a collection of ranges, this property always indicates a single value '{start}', the location in the file where the next upload should begin.
@@ -35,7 +35,7 @@ public interface IUploadSession extends Parsable, AdditionalDataHolder {
      * Sets the ranges that are yet to be uploaded.
      * @param nextExpectedRanges the byte ranges yet to be uploaded.
      */
-    void setNextExpectedRanges(@Nonnull List<String> nextExpectedRanges);
+    void setNextExpectedRanges(@Nonnull final List<String> nextExpectedRanges);
     /**
      * Expiration date of the upload session
      * @return the expiration date.
@@ -46,5 +46,5 @@ public interface IUploadSession extends Parsable, AdditionalDataHolder {
      * Set the expiration date of the UploadSession
      * @param dateTime the expiration date of the UploadSession.
      */
-    void setExpirationDateTime(@Nonnull OffsetDateTime dateTime);
+    void setExpirationDateTime(@Nonnull final OffsetDateTime dateTime);
 }

--- a/src/main/java/com/microsoft/graph/core/models/UploadSession.java
+++ b/src/main/java/com/microsoft/graph/core/models/UploadSession.java
@@ -55,9 +55,12 @@ public class UploadSession implements IUploadSession {
      * Get the next upload byte ranges to be uploaded.
      * @return The byte ranges to be uploaded.
      */
-    @Nonnull
+    @Nullable
     @Override
     public List<String> getNextExpectedRanges() {
+        if (nextExpectedRanges == null) {
+            return null;
+        }
         return new ArrayList<>(nextExpectedRanges);
     }
     /**

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
@@ -56,16 +56,15 @@ public class UploadResponseHandler {
             }
             try(final InputStream in = body.byteStream()){
                 final String contentType = body.contentType().toString().split(";")[0]; //contentType.toString() returns in format <mediaType>;<charset>, we only want the mediaType.
-                int responseCode = response.code();
                 if(!response.isSuccessful()) {
                     throw new ApiExceptionBuilder()
                             .withMessage(ErrorConstants.Codes.GENERAL_EXCEPTION)
-                            .withResponseStatusCode(responseCode)
+                            .withResponseStatusCode(response.code())
                             .withResponseHeaders(HeadersCompatibility.getResponseHeaders(response.headers()))
                             .build();
                 }
                 UploadResult<T> uploadResult = new UploadResult<>();
-                if (responseCode == HttpURLConnection.HTTP_CREATED || responseCode == HttpURLConnection.HTTP_OK) {
+                if (response.code() == HttpURLConnection.HTTP_CREATED) {
                     if (body.contentLength() > 0) {
                         final ParseNode uploadTypeParseNode = parseNodeFactory.getParseNode(contentType, in);
                         uploadResult.itemResponse = uploadTypeParseNode.getObjectValue(factory);

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -76,7 +77,8 @@ public class UploadResponseHandler {
                 } else {
                     final ParseNode parseNode = parseNodeFactory.getParseNode(contentType, in);
                     final UploadSession uploadSession = parseNode.getObjectValue(UploadSession::createFromDiscriminatorValue);
-                    if (!uploadSession.getNextExpectedRanges().isEmpty()) {
+                    final List<String> nextExpectedRanges = uploadSession.getNextExpectedRanges();
+                    if (!(nextExpectedRanges == null || nextExpectedRanges.isEmpty())) {
                         uploadResult.uploadSession = uploadSession;
                     } else {
                         uploadResult.itemResponse = parseNode.getObjectValue(factory);

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
@@ -56,15 +56,16 @@ public class UploadResponseHandler {
             }
             try(final InputStream in = body.byteStream()){
                 final String contentType = body.contentType().toString().split(";")[0]; //contentType.toString() returns in format <mediaType>;<charset>, we only want the mediaType.
+                int responseCode = response.code();
                 if(!response.isSuccessful()) {
                     throw new ApiExceptionBuilder()
                             .withMessage(ErrorConstants.Codes.GENERAL_EXCEPTION)
-                            .withResponseStatusCode(response.code())
+                            .withResponseStatusCode(responseCode)
                             .withResponseHeaders(HeadersCompatibility.getResponseHeaders(response.headers()))
                             .build();
                 }
                 UploadResult<T> uploadResult = new UploadResult<>();
-                if (response.code() == HttpURLConnection.HTTP_CREATED) {
+                if (responseCode == HttpURLConnection.HTTP_CREATED || responseCode == HttpURLConnection.HTTP_OK) {
                     if (body.contentLength() > 0) {
                         final ParseNode uploadTypeParseNode = parseNodeFactory.getParseNode(contentType, in);
                         uploadResult.itemResponse = uploadTypeParseNode.getObjectValue(factory);

--- a/src/test/java/com/microsoft/graph/core/requests/upload/UploadResponseHandlerTest.java
+++ b/src/test/java/com/microsoft/graph/core/requests/upload/UploadResponseHandlerTest.java
@@ -119,9 +119,9 @@ class UploadResponseHandlerTest {
         Response response = new Response.Builder()
             .request(mock(Request.class))
             .protocol(mock(Protocol.class))
-            .message("OK")
+            .message("Accepted")
             .body(body)
-            .code(HttpURLConnection.HTTP_OK)
+            .code(HttpURLConnection.HTTP_ACCEPTED)
             .build();
         UploadResult<TestDriveItem> result = responseHandler
             .handleResponse(response, TestDriveItem::createFromDiscriminatorValue);
@@ -135,7 +135,7 @@ class UploadResponseHandlerTest {
         assertEquals("77829-99375", session.getNextExpectedRanges().get(1));
         assertEquals(2, session.getNextExpectedRanges().size());
     }
-    
+
     @Test
     void throwsServiceExceptionOnErrorResponse() {
         UploadResponseHandler responseHandler = new UploadResponseHandler(null);

--- a/src/test/java/com/microsoft/graph/core/requests/upload/UploadResponseHandlerTest.java
+++ b/src/test/java/com/microsoft/graph/core/requests/upload/UploadResponseHandlerTest.java
@@ -51,6 +51,36 @@ class UploadResponseHandlerTest {
         assertEquals("largeFile.vhd", item.name);
         assertEquals(33, item.size);
     }
+
+    @Test
+    void GetUploadItemOnCompletedUpdate() {
+        registry.contentTypeAssociatedFactories.put(CoreConstants.MimeTypeNames.APPLICATION_JSON, new JsonParseNodeFactory());
+
+        UploadResponseHandler responseHandler = new UploadResponseHandler(null);
+        ResponseBody body = ResponseBody.create("{\n" +
+                "   \"id\": \"912310013A123\",\n" +
+                "   \"name\": \"largeFile.vhd\",\n" +
+                "   \"size\": 33\n" +
+                "}"
+            , MediaType.parse(CoreConstants.MimeTypeNames.APPLICATION_JSON));
+        Response response = new Response.Builder()
+            .request(mock(Request.class))
+            .protocol(mock(Protocol.class))
+            .body(body)
+            .code(HttpURLConnection.HTTP_OK)
+            .message("OK")
+            .build();
+        UploadResult<TestDriveItem> result = responseHandler
+            .handleResponse(response, TestDriveItem::createFromDiscriminatorValue);
+        responseHandler.handleResponse(response, parseNode -> {return new TestDriveItem();});
+        TestDriveItem item = result.itemResponse;
+        assertTrue(result.isUploadSuccessful());
+        assertNotNull(item);
+        assertEquals("912310013A123", item.id);
+        assertEquals("largeFile.vhd", item.name);
+        assertEquals(33, item.size);
+    }
+
     @Test
     void getFileAttachmentLocationOnCompletedUpload() {
         registry.contentTypeAssociatedFactories.put(CoreConstants.MimeTypeNames.APPLICATION_JSON, new JsonParseNodeFactory());
@@ -105,6 +135,7 @@ class UploadResponseHandlerTest {
         assertEquals("77829-99375", session.getNextExpectedRanges().get(1));
         assertEquals(2, session.getNextExpectedRanges().size());
     }
+    
     @Test
     void throwsServiceExceptionOnErrorResponse() {
         UploadResponseHandler responseHandler = new UploadResponseHandler(null);

--- a/src/test/java/com/microsoft/graph/core/requests/upload/UploadSessionTest.java
+++ b/src/test/java/com/microsoft/graph/core/requests/upload/UploadSessionTest.java
@@ -1,0 +1,19 @@
+package com.microsoft.graph.core.requests.upload;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.graph.core.models.UploadSession;
+
+class UploadSessionTest {
+    @Test
+    void getNextExpectedRangesDoesNotFailOnDefault()
+    {
+        final UploadSession uploadSession = new UploadSession();
+        final List<String> result = uploadSession.getNextExpectedRanges();
+        assertNull(result);
+    }
+}

--- a/src/test/java/com/microsoft/graph/core/requests/upload/UploadSliceRequestTest.java
+++ b/src/test/java/com/microsoft/graph/core/requests/upload/UploadSliceRequestTest.java
@@ -40,9 +40,9 @@ class UploadSliceRequestTest {
         Response response = new Response.Builder()
             .request(new Request.Builder().post(mock(RequestBody.class)).url("https://a.b.c/").build())
             .protocol(Protocol.HTTP_1_1)
-            .message("OK")
+            .message("Accepted")
             .body(body)
-            .code(HttpURLConnection.HTTP_OK)
+            .code(HttpURLConnection.HTTP_ACCEPTED)
             .build();
 
         OkHttpClient mockClient = getMockClient(response);


### PR DESCRIPTION
- Fixes #1517. 
- In addition a test not respecting the REST reference was corrected.

### Changes proposed in this pull request
The test UploadResponseHandlerTest#getUploadSessionOnProgressingUpload mimicked a server response with a 200/OK response code.
In the REST reference (https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0#upload-bytes-to-the-upload-session) it is stated that the response code for uploading more bytes to the upload session is 202/Accepted.
The bug in https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1517 is fixed.
Previously the method UploadResponseHandler#handleResponse handled differently the response in these two cases:
- response code 200/OK
- all other cases

Now the same method handles differently the response in these two cases:
- response code 200/OK or 201/Created
- all other cases

Everything works if the REST reference is corrected and:
- 200/OK is returned when an item is updated, 201/Created is returned when an item is Created
- 202/Accepted is returned when more bytes are requested