### PR TITLE
Update LargeFileUploadTask.java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.7]
 
 ### Added
 
 ### Changed
+- Changed chunkInputStream method in LargeFileUploadTask to resolve IndexOutOfBoundsException when uploading large files
 
 ## [3.1.6] - 2024-02-29
 

--- a/src/main/java/com/microsoft/graph/core/tasks/LargeFileUploadTask.java
+++ b/src/main/java/com/microsoft/graph/core/tasks/LargeFileUploadTask.java
@@ -1,23 +1,5 @@
 package com.microsoft.graph.core.tasks;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.time.OffsetDateTime;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import com.microsoft.graph.core.ErrorConstants;
 import com.microsoft.graph.core.exceptions.ClientException;
 import com.microsoft.graph.core.models.IProgressCallback;
@@ -36,8 +18,19 @@ import com.microsoft.kiota.authentication.AnonymousAuthenticationProvider;
 import com.microsoft.kiota.serialization.Parsable;
 import com.microsoft.kiota.serialization.ParsableFactory;
 import com.microsoft.kiota.serialization.ParseNode;
-
 import okhttp3.OkHttpClient;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * Task for uploading large files including pausing and resuming.
@@ -144,7 +137,7 @@ public class LargeFileUploadTask<T extends Parsable > {
                         return result;
                     }
                 }
-                //updateSessionStatus();
+                updateSessionStatus();
                 uploadTries += 1;
                 if (uploadTries < maxTries) {
                     TimeUnit.SECONDS.sleep((long) 2 * uploadTries * uploadTries);


### PR DESCRIPTION
Suggested modification to the chunkInputStream method:

From the second pass through this method, the code in the line "int lengthAssert = stream.read(buffer, begin, length);" throws the exception java.lang.IndexOutOfBoundsException when trying to assign the read bytes to a non-existent position in the buffer.

The suggested change implies changing InputStream to FileInputStream throughout the LargeFileUploadTask class.

<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes # IndexOutOfBoundException in method chunkInputStream

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Change InputStream to FileInputStream.
- Change
`byte[] buffer = new byte[length];
int lengthAssert = stream.read(buffer, begin, length);` 
to 
`ByteBuffer byteBuffer = ByteBuffer.allocate(length);
int lengthAssert = stream.getChannel().read(byteBuffer);
byteBuffer.flip();
byte[] buffer = byteBuffer.array(); byteBuffer.clear()`; 

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
-
