### PR TITLE
Fix large file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [3.1.7]
+## [3.1.8]
 
 ### Added
 
 ### Changed
 - Changed chunkInputStream method in LargeFileUploadTask to resolve IndexOutOfBoundsException when uploading large files
-- Fix Large File Upload bug where exception was thrown for completed successful uploads with Location header
+- Fix Large File Upload bug where exception was thrown for completed successful uploads
 
 ## [3.1.7] - 2024-03-28
 
@@ -68,13 +68,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bump for Java SDK GA release.
-- Bumps Kiota-Java abstractions, authentication, http, and serialization components for Java SDK 6.1.0 release. 
+- Bumps Kiota-Java abstractions, authentication, http, and serialization components for Java SDK 6.1.0 release.
 
 ## [3.0.12] - 2023-12-15
 
-### Fixed 
+### Fixed
 
-- Fixes a bug where a null collection for allowedHosts would result in failure to initialize client. [#1411](https://github.com/microsoftgraph/msgraph-sdk-java-core/pull/1411) 
+- Fixes a bug where a null collection for allowedHosts would result in failure to initialize client. [#1411](https://github.com/microsoftgraph/msgraph-sdk-java-core/pull/1411)
 
 ## [3.0.11] - 2023-12-08
 
@@ -85,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.10] - 2023-11-27
 
-### Changed 
+### Changed
 
 - Removed the usage of reflection for enum deserialization and reordered RequestAdapter method arguments. [Kiota-Java #840](https://github.com/microsoft/kiota-java/issues/840)
 
@@ -108,13 +108,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removes 'SuppressFBWarnings' annotations and dependency.  
+- Removes 'SuppressFBWarnings' annotations and dependency.
 
 ## [3.0.7] - 2023-07-20
 
 ### Added
 
-- Adds graph-java-sdk implementation of the `UrlReplaceHandler` middleware including default replacement pairs. 
+- Adds graph-java-sdk implementation of the `UrlReplaceHandler` middleware including default replacement pairs.
 - Default replacement pair: '/users/TokenToReplace' -> '/me'
 
 ## [3.0.6] - 2023-07-11
@@ -131,11 +131,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.4] - 2023-05-03
 
-### Added 
- 
-- Added LargeFileUploadTask functionality for kiota generated service libraries. 
+### Added
 
-### Fixed 
+- Added LargeFileUploadTask functionality for kiota generated service libraries.
+
+### Fixed
 
 - Fixes formatting used in the headers added by the telemetry handler to align with the [msGraph sdk spec.](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/middleware/TelemetryHandler.md)
 
@@ -179,7 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   private OkHttpClient createClient(@Nonnull final IAuthenticationProvider auth) {
     return HttpClients.createDefault(auth);
   }
-  
+
   // then create the GraphServiceClient
     IAuthenticationProvider authenticationProvider = ...;
     GraphServiceClient
@@ -191,16 +191,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.20] - 2023-10-23
 
-### Changed 
+### Changed
 
-- Updates Okhttp3 to avoid transient vulnerabilty. [#1038](https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1038) 
+- Updates Okhttp3 to avoid transient vulnerabilty. [#1038](https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1038)
 
 ## [2.0.19] - 2023-06-20
 
 ### Changed
 
 - Remove explicit logging of GraphServiceException in the CoreHttpProvider class. [#885](https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/885)
-- Thank you to @MaHa6543 for the contribution. 
+- Thank you to @MaHa6543 for the contribution.
 
 ## [2.0.18] - 2023-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
 ## [3.1.7]
 
 ### Added
 
 ### Changed
 - Changed chunkInputStream method in LargeFileUploadTask to resolve IndexOutOfBoundsException when uploading large files
+- Fix Large File Upload bug where exception was thrown for completed successful uploads with Location header
 
 ## [3.1.7] - 2024-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.7]
 
 ### Added
 
 ### Changed
+- Changed chunkInputStream method in LargeFileUploadTask to resolve IndexOutOfBoundsException when uploading large files
 
 ## [3.1.7] - 2024-03-28
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph-core
 mavenMajorVersion    = 3
 mavenMinorVersion    = 1
-mavenPatchVersion    = 7
+mavenPatchVersion    = 8
 mavenArtifactSuffix =
 
 #These values are used to run functional tests

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,9 @@ dependencies {
     testImplementation 'io.opentelemetry:opentelemetry-api:1.37.0'
     testImplementation 'io.opentelemetry:opentelemetry-context:1.37.0'
     testImplementation 'io.github.std-uritemplate:std-uritemplate:0.0.56'
-    
+    testImplementation 'io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha'
+    testImplementation 'io.opentelemetry.semconv:opentelemetry-semconv-incubating:1.25.0-alpha'
+
     implementation 'com.google.code.gson:gson:2.10.1'
 
     implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,8 +7,6 @@ dependencies {
     testImplementation 'io.opentelemetry:opentelemetry-api:1.37.0'
     testImplementation 'io.opentelemetry:opentelemetry-context:1.37.0'
     testImplementation 'io.github.std-uritemplate:std-uritemplate:0.0.56'
-    testImplementation 'io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha'
-    testImplementation 'io.opentelemetry.semconv:opentelemetry-semconv-incubating:1.25.0-alpha'
 
     implementation 'com.google.code.gson:gson:2.10.1'
 
@@ -17,11 +15,11 @@ dependencies {
     api 'com.squareup.okhttp3:okhttp:4.12.0'
     api 'com.azure:azure-core:1.48.0'
 
-    api 'com.microsoft.kiota:microsoft-kiota-abstractions:1.1.4'
-    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.1.4'
-    implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.1.4'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.1.4'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.1.4'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.1.4'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.1.4'
+    api 'com.microsoft.kiota:microsoft-kiota-abstractions:1.1.6'
+    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.1.6'
+    implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.1.6'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.1.6'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.1.6'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.1.6'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.1.6'
 }

--- a/src/main/java/com/microsoft/graph/core/CoreConstants.java
+++ b/src/main/java/com/microsoft/graph/core/CoreConstants.java
@@ -14,7 +14,7 @@ public final class CoreConstants {
     private static class VersionValues {
         private static final int MAJOR = 3;
         private static final int MINOR = 1;
-        private static final int PATCH = 7;
+        private static final int PATCH = 8;
     }
 
     /**

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
@@ -53,7 +53,11 @@ public class UploadResponseHandler {
         Objects.requireNonNull(factory);
         try (final ResponseBody body = response.body()) {
             UploadResult<T> uploadResult = new UploadResult<>();
-            if (Objects.isNull(body)) {
+            String contentLengthHeader = response.headers().get("content-length");
+            if (Objects.isNull(body)
+                || Objects.isNull(body.contentType())
+                || (!Objects.isNull(contentLengthHeader) && Integer.parseInt(contentLengthHeader) == 0)
+            ) {
                 if (response.code() == HttpURLConnection.HTTP_CREATED) {
                     final String location = response.headers().get("location");
                     if(!Objects.isNull(location) && !location.isEmpty()) {
@@ -71,8 +75,7 @@ public class UploadResponseHandler {
                             .withResponseHeaders(HeadersCompatibility.getResponseHeaders(response.headers()))
                             .build();
                 }
-                String contentLengthHeader = response.headers().get("content-length");
-                boolean canBeParsed = (!Objects.isNull(contentLengthHeader) && Integer.valueOf(contentLengthHeader) > 0) || !Objects.isNull(body.contentType());
+                boolean canBeParsed = (!Objects.isNull(contentLengthHeader) && Integer.parseInt(contentLengthHeader) > 0) || !Objects.isNull(body.contentType());
                 String contentType = canBeParsed ? body.contentType().toString().split(";")[0] : null; //contentType.toString() returns in format <mediaType>;<charset>, we only want the mediaType.
                 if (canBeParsed) {
                     final ParseNode parseNode = parseNodeFactory.getParseNode(contentType, in);

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
@@ -54,6 +54,9 @@ public class UploadResponseHandler {
         try (final ResponseBody body = response.body()) {
             UploadResult<T> uploadResult = new UploadResult<>();
             String contentLengthHeader = response.headers().get("content-length");
+            // rely on content-type OR content-length headers to determine if response body is empty.
+            // Response body() may be non-null despite being empty in raw response https://square.github.io/okhttp/3.x/okhttp/okhttp3/Response.html#body--
+            // content-length header is not always present in Graph responses. Content-type is more reliable
             if (Objects.isNull(body)
                 || Objects.isNull(body.contentType())
                 || (!Objects.isNull(contentLengthHeader) && Integer.parseInt(contentLengthHeader) == 0)

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
@@ -71,7 +71,8 @@ public class UploadResponseHandler {
                             .withResponseHeaders(HeadersCompatibility.getResponseHeaders(response.headers()))
                             .build();
                 }
-                boolean canBeParsed = ((!Objects.isNull(body.contentType())) && (body.contentLength() > 0));
+                String contentLengthHeader = response.headers().get("content-length");
+                boolean canBeParsed = (!Objects.isNull(contentLengthHeader) && Integer.valueOf(contentLengthHeader) > 0) || !Objects.isNull(body.contentType());
                 String contentType = canBeParsed ? body.contentType().toString().split(";")[0] : null; //contentType.toString() returns in format <mediaType>;<charset>, we only want the mediaType.
                 if (canBeParsed) {
                     final ParseNode parseNode = parseNodeFactory.getParseNode(contentType, in);

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadResponseHandler.java
@@ -73,29 +73,17 @@ public class UploadResponseHandler {
                 }
                 boolean canBeParsed = ((!Objects.isNull(body.contentType())) && (body.contentLength() > 0));
                 String contentType = canBeParsed ? body.contentType().toString().split(";")[0] : null; //contentType.toString() returns in format <mediaType>;<charset>, we only want the mediaType.
-                if (response.code() == HttpURLConnection.HTTP_CREATED) {
-                    if(canBeParsed) {
-                        final ParseNode uploadTypeParseNode = parseNodeFactory.getParseNode(contentType, in);
-                        uploadResult.itemResponse = uploadTypeParseNode.getObjectValue(factory);
-                    }
-                    final String location = response.headers().get("location");
-                    if(!Objects.isNull(location) && !location.isEmpty()) {
-                        uploadResult.location = new URI(location);
-                    }
-                } else {
-                    if(canBeParsed) {
-                        final ParseNode parseNode = parseNodeFactory.getParseNode(contentType, in);
+                if (canBeParsed) {
+                    final ParseNode parseNode = parseNodeFactory.getParseNode(contentType, in);
+                    if (response.code() == HttpURLConnection.HTTP_CREATED) {
+                        uploadResult.itemResponse = parseNode.getObjectValue(factory);
+                    } else {
                         final UploadSession uploadSession = parseNode.getObjectValue(UploadSession::createFromDiscriminatorValue);
                         final List<String> nextExpectedRanges = uploadSession.getNextExpectedRanges();
                         if (!(nextExpectedRanges == null || nextExpectedRanges.isEmpty())) {
                             uploadResult.uploadSession = uploadSession;
                         } else {
                             uploadResult.itemResponse = parseNode.getObjectValue(factory);
-                        }
-                    } else {
-                        final String location = response.headers().get("location");
-                        if (!Objects.isNull(location) && !location.isEmpty()) {
-                            uploadResult.location = new URI(location);
                         }
                     }
                 }

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadSessionRequestBuilder.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadSessionRequestBuilder.java
@@ -2,7 +2,6 @@ package com.microsoft.graph.core.requests.upload;
 
 import com.microsoft.graph.core.models.IUploadSession;
 import com.microsoft.graph.core.models.UploadResult;
-import com.microsoft.graph.core.models.UploadSession;
 import com.microsoft.kiota.*;
 import com.microsoft.kiota.serialization.Parsable;
 import com.microsoft.kiota.serialization.ParsableFactory;

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadSessionRequestBuilder.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadSessionRequestBuilder.java
@@ -47,7 +47,11 @@ public class UploadSessionRequestBuilder<T extends Parsable> {
     @Nonnull
     public IUploadSession get() {
         RequestInformation requestInformation = toGetRequestInformation();
-        return requestAdapter.send(requestInformation, null, UploadSession::createFromDiscriminatorValue);
+        NativeResponseHandler nativeResponseHandler = new NativeResponseHandler();
+        requestInformation.setResponseHandler(nativeResponseHandler);
+        requestAdapter.sendPrimitive(requestInformation, null,  InputStream.class);
+        UploadResult<T> result = responseHandler.handleResponse((Response) nativeResponseHandler.getValue(), factory);
+        return result.uploadSession;
     }
     private RequestInformation toGetRequestInformation() {
         RequestInformation requestInformation = new RequestInformation();

--- a/src/main/java/com/microsoft/graph/core/requests/upload/UploadSessionRequestBuilder.java
+++ b/src/main/java/com/microsoft/graph/core/requests/upload/UploadSessionRequestBuilder.java
@@ -2,6 +2,7 @@ package com.microsoft.graph.core.requests.upload;
 
 import com.microsoft.graph.core.models.IUploadSession;
 import com.microsoft.graph.core.models.UploadResult;
+import com.microsoft.graph.core.models.UploadSession;
 import com.microsoft.kiota.*;
 import com.microsoft.kiota.serialization.Parsable;
 import com.microsoft.kiota.serialization.ParsableFactory;
@@ -46,11 +47,7 @@ public class UploadSessionRequestBuilder<T extends Parsable> {
     @Nonnull
     public IUploadSession get() {
         RequestInformation requestInformation = toGetRequestInformation();
-        NativeResponseHandler nativeResponseHandler = new NativeResponseHandler();
-        requestInformation.setResponseHandler(nativeResponseHandler);
-        requestAdapter.sendPrimitive(requestInformation, null,  InputStream.class);
-        UploadResult<T> result = responseHandler.handleResponse((Response) nativeResponseHandler.getValue(), factory);
-        return result.uploadSession;
+        return requestAdapter.send(requestInformation, null, UploadSession::createFromDiscriminatorValue);
     }
     private RequestInformation toGetRequestInformation() {
         RequestInformation requestInformation = new RequestInformation();

--- a/src/main/java/com/microsoft/graph/core/tasks/LargeFileUploadTask.java
+++ b/src/main/java/com/microsoft/graph/core/tasks/LargeFileUploadTask.java
@@ -1,23 +1,5 @@
 package com.microsoft.graph.core.tasks;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.time.OffsetDateTime;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import com.microsoft.graph.core.ErrorConstants;
 import com.microsoft.graph.core.exceptions.ClientException;
 import com.microsoft.graph.core.models.IProgressCallback;
@@ -36,8 +18,19 @@ import com.microsoft.kiota.authentication.AnonymousAuthenticationProvider;
 import com.microsoft.kiota.serialization.Parsable;
 import com.microsoft.kiota.serialization.ParsableFactory;
 import com.microsoft.kiota.serialization.ParseNode;
-
 import okhttp3.OkHttpClient;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * Task for uploading large files including pausing and resuming.
@@ -144,7 +137,7 @@ public class LargeFileUploadTask<T extends Parsable > {
                         return result;
                     }
                 }
-                //updateSessionStatus();
+                updateSessionStatus();
                 uploadTries += 1;
                 if (uploadTries < maxTries) {
                     TimeUnit.SECONDS.sleep((long) 2 * uploadTries * uploadTries);


### PR DESCRIPTION
- Fixes issue with reading chunks to upload from the InputStream to a buffer that would throw `IndexOutOfBoundsException`
- Fixes issue with checking for presence of a response body. Uses `content-length` header instead of okHttp's native `Response` `contentLength()` which is unreliable at times or checking if `body()` or Response is null since it'll always be [non-null](https://square.github.io/okhttp/3.x/okhttp/okhttp3/Response.html#body--) based on our use of `Call.execute()`
This fixes Outlook LFU scenarios by preventing it from trying to parse a null body.
- Updates tests to simulate reponse objects returned by `Call.execute()` which will always have non-null `body()`.

closes https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1543
closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1818
closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1806
closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1943