### PR TITLE
Downgrade `jakarta.annotation-api` dependency for java 8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [3.1.10] - 2024-05-09
+
+### Changed
+
+- Downgraded `jakarta.annotation-api` dependency to `2.1.1` for java 8 compatibility
+
 ## [3.1.9] - 2024-04-23
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.graph
 mavenArtifactId      = microsoft-graph-core
 mavenMajorVersion    = 3
 mavenMinorVersion    = 1
-mavenPatchVersion    = 9
+mavenPatchVersion    = 10
 mavenArtifactSuffix =
 
 #These values are used to run functional tests

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'io.github.std-uritemplate:std-uritemplate:0.0.57'
     implementation 'com.google.code.gson:gson:2.10.1'
 
-    implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
+    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 
     api 'com.squareup.okhttp3:okhttp:4.12.0'
     api 'com.azure:azure-core:1.49.0'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,11 +14,11 @@ dependencies {
     api 'com.squareup.okhttp3:okhttp:4.12.0'
     api 'com.azure:azure-core:1.49.0'
 
-    api 'com.microsoft.kiota:microsoft-kiota-abstractions:1.1.10'
-    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.1.10'
-    implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.1.10'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.1.10'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.1.10'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.1.10'
-    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.1.10'
+    api 'com.microsoft.kiota:microsoft-kiota-abstractions:1.1.11'
+    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.1.11'
+    implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.1.11'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.1.11'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.1.11'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.1.11'
+    implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.1.11'
 }

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     // Include the sdk as a dependency
-    implementation 'com.microsoft.graph:microsoft-graph-core:3.1.6'
+    implementation 'com.microsoft.graph:microsoft-graph-core:3.1.10'
     // This dependency is only needed if you are using the TokenCredentialAuthProvider
     implementation 'com.azure:azure-identity:1.11.0'
 }
@@ -37,7 +37,7 @@ Add the dependency in `dependencies` in pom.xml
     <!-- Include the sdk as a dependency -->
     <groupId>com.microsoft.graph</groupId>
     <artifactId>microsoft-graph-core</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.10</version>
     <!-- This dependency is only needed if you are using the TokenCredentialAuthProvider -->
     <groupId>com.azure</groupId>
     <artifactId>azure-identity</artifactId>
@@ -85,9 +85,9 @@ client.newCall(request).enqueue(new Callback() {
 	@Override
 	public void onResponse(Call call, Response response) throws IOException {
 		String responseBody = response.body().string();
-		// Your processing with the response body 
+		// Your processing with the response body
 	}
-			
+
 	@Override
 	public void onFailure(Call call, IOException e) {
 		e.printStackTrace();
@@ -106,9 +106,9 @@ client.newCall(request).enqueue(new Callback() {
 	@Override
 	public void onResponse(Call call, Response response) throws IOException {
 		String responseBody = response.body().string();
-		// Your processing with the response body 
+		// Your processing with the response body
 	}
-			
+
 	@Override
 	public void onFailure(Call call, IOException e) {
 		e.printStackTrace();

--- a/src/main/java/com/microsoft/graph/core/CoreConstants.java
+++ b/src/main/java/com/microsoft/graph/core/CoreConstants.java
@@ -14,7 +14,7 @@ public final class CoreConstants {
     private static class VersionValues {
         private static final int MAJOR = 3;
         private static final int MINOR = 1;
-        private static final int PATCH = 9;
+        private static final int PATCH = 10;
     }
 
     /**


### PR DESCRIPTION
Temporary manual downgrade of `jakarta.annotation-api` until https://github.com/microsoft/kiota-java/pull/1259 can be replicated in this repo.