### PR TITLE
Add Java 8 compatibility checks to CI

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -22,6 +22,9 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Build with Java 8
+        working-directory: ./java-8
+        run: .././gradlew build
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/java-8/.gitignore
+++ b/java-8/.gitignore
@@ -1,0 +1,2 @@
+.gradle
+build/

--- a/java-8/build.gradle
+++ b/java-8/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    // Apply the java-library plugin to add support for Java Library
+    id 'java-library'
+    id 'eclipse'
+}
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['../src']
+            exclude 'test/**'
+        }
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+    withSourcesJar()
+}
+
+apply from: "../gradle/dependencies.gradle"

--- a/java-8/gradle.properties
+++ b/java-8/gradle.properties
@@ -1,0 +1,1 @@
+mavenArtifactId      = msgraph-sdk-java-core

--- a/java-8/settings.gradle
+++ b/java-8/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'msgraph-sdk-java-core'


### PR DESCRIPTION
- Adds sub-project configured for Java 8 to prevent conflicts with plugins in main build.gradle
- Updates build workflow

related to https://github.com/microsoftgraph/msgraph-sdk-java/issues/1979