### PR TITLE
ci: adds missing gradle dependencies caching to CI

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 20
+          cache: gradle
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3.2.1
       - name: Add execution right to the script


### PR DESCRIPTION
related https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons