### PR TITLE
Fix Secrets Scanning Workflow

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -16,8 +16,10 @@ jobs:
           java-version: 20
           distribution: 'temurin'
           cache: gradle
-      - name: Easy detect-secrets
-        uses: RobertFischer/detect-secrets-action@v2.0.0
+      - name: Detect secrets
+        run: |
+          pip install detect-secrets
+          git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -67,6 +67,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -75,6 +79,12 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
     },
     {
       "path": "detect_secrets.filters.heuristic.is_potential_uuid"
@@ -86,15 +96,18 @@
       "path": "detect_secrets.filters.heuristic.is_sequential_string"
     },
     {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     },
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "gradle.properties"
+        "release-please-config.json"
       ]
     }
   ],
   "results": {},
-  "generated_at": "2021-09-09T20:53:20Z"
+  "generated_at": "2024-08-12T15:21:45Z"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -28,15 +28,8 @@ mavenArtifactId      = microsoft-graph-core
 mavenMajorVersion    = 3
 mavenMinorVersion    = 1
 mavenPatchVersion    = 0
-mavenArtifactSuffix = 
+mavenArtifactSuffix =
 
-#These values are used to run functional tests
-#If you wish to run the functional tests, edit the gradle.properties
-#file in your user directory instead of adding them here.
-#ex: C:\Users\username\.gradle\gradle.properties
-ClientId="CLIENT_ID"
-Username="USERNAME"
-Password="PASSWORD"
 
 #enable mavenCentralPublishingEnabled to publish to maven central
 mavenCentralSnapshotArtifactSuffix = -SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,14 +34,6 @@ mavenPatchVersion    = 15
 # x-release-please-end
 mavenArtifactSuffix =
 
-#These values are used to run functional tests
-#If you wish to run the functional tests, edit the gradle.properties
-#file in your user directory instead of adding them here.
-#ex: C:\Users\username\.gradle\gradle.properties
-ClientId="CLIENT_ID"
-Username="USERNAME"
-Password="PASSWORD"
-
 #enable mavenCentralPublishingEnabled to publish to maven central
 mavenCentralSnapshotArtifactSuffix = -SNAPSHOT
 mavenCentralPublishingEnabled=false

--- a/src/test/java/com/microsoft/graph/core/content/BatchResponseContentTest.java
+++ b/src/test/java/com/microsoft/graph/core/content/BatchResponseContentTest.java
@@ -109,27 +109,7 @@ class BatchResponseContentTest {
             "\"Content-Type\": \"image/jpeg\"," +
             "\"ETag\": \"BEB9D79C\"" +
             "}," +
-            "\"body\": \"iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZ" +
-            "SBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77" +
-            "u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM" +
-            "6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0x" +
-            "NDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyL" +
-            "zIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodH" +
-            "RwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXA" +
-            "vMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJj" +
-            "ZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc" +
-            "3RhbmNlSUQ9InhtcC5paWQ6MEVBMTczNDg3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiIHhtcE1NOkRvY3VtZW" +
-            "50SUQ9InhtcC5kaWQ6MEVBMTczNDk3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiPiA8eG1wTU06RGVyaXZlZEZ" +
-            "yb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowRUExNzM0NjdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIg" +
-            "c3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDowRUExNzM0NzdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIvPiA8L" +
-            "3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PjjUms" +
-            "sAAAGASURBVHjatJaxTsMwEIbpIzDA6FaMMPYJkDKzVYU+QFeEGPIKfYU8AETkCYI6wANkZQwIKRNDB1hA0Jr" +
-            "f0rk6WXZ8BvWkb4kv99vn89kDrfVexBSYgVNwDA7AN+jAK3gEd+AlGMGIBFDgFvzouK3JV/lihQTOwLtOtw9w" +
-            "IRG5pJn91Tbgqk9kSk7GViADrTD4HCyZ0NQnomi51sb0fUyCMQEbp2WpU67IjfNjwcYyoUDhjJVcZBjYBy40j" +
-            "4wXgaobWoe8Z6Y80CJBwFpunepIzt2AUgFjtXXshNXjVmMh+K+zzp/CMs0CqeuzrxSRpbOKfdCkiMTS1VBQ41" +
-            "uxMyQR2qbrXiiwYN3ACh1FDmsdK2Eu4J6Tlo31dYVtCY88h5ELZIJJ+IRMzBHfyJINrigNkt5VsRiub9nXICd" +
-            "sYyVd2NcVvA3ScE5t2rb5JuEeyZnAhmLt9NK63vX1O5Pe8XaPSuGq1uTrfUgMEp9EJ+CQvr+BJ/AAKvAcCiAR" +
-            "+bf9CjAAluzmdX4AEIIAAAAASUVORK5CYII=\"" +
+            "\"body\": \"iVBORw0K\"" +
             "}" +
             "]}";
         ResponseBody body = ResponseBody.create(responseJSON, MediaType.parse("application/json"));
@@ -156,27 +136,7 @@ class BatchResponseContentTest {
             "\"Content-Type\": \"image/jpeg\"," +
             "\"ETag\": \"BEB9D79C\"" +
             "}," +
-            "\"body\": \"iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZ" +
-            "SBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77" +
-            "u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM" +
-            "6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0x" +
-            "NDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyL" +
-            "zIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodH" +
-            "RwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXA" +
-            "vMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJj" +
-            "ZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc" +
-            "3RhbmNlSUQ9InhtcC5paWQ6MEVBMTczNDg3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiIHhtcE1NOkRvY3VtZW" +
-            "50SUQ9InhtcC5kaWQ6MEVBMTczNDk3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiPiA8eG1wTU06RGVyaXZlZEZ" +
-            "yb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowRUExNzM0NjdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIg" +
-            "c3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDowRUExNzM0NzdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIvPiA8L" +
-            "3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PjjUms" +
-            "sAAAGASURBVHjatJaxTsMwEIbpIzDA6FaMMPYJkDKzVYU+QFeEGPIKfYU8AETkCYI6wANkZQwIKRNDB1hA0Jr" +
-            "f0rk6WXZ8BvWkb4kv99vn89kDrfVexBSYgVNwDA7AN+jAK3gEd+AlGMGIBFDgFvzouK3JV/lihQTOwLtOtw9w" +
-            "IRG5pJn91Tbgqk9kSk7GViADrTD4HCyZ0NQnomi51sb0fUyCMQEbp2WpU67IjfNjwcYyoUDhjJVcZBjYBy40j" +
-            "4wXgaobWoe8Z6Y80CJBwFpunepIzt2AUgFjtXXshNXjVmMh+K+zzp/CMs0CqeuzrxSRpbOKfdCkiMTS1VBQ41" +
-            "uxMyQR2qbrXiiwYN3ACh1FDmsdK2Eu4J6Tlo31dYVtCY88h5ELZIJJ+IRMzBHfyJINrigNkt5VsRiub9nXICd" +
-            "sYyVd2NcVvA3ScE5t2rb5JuEeyZnAhmLt9NK63vX1O5Pe8XaPSuGq1uTrfUgMEp9EJ+CQvr+BJ/AAKvAcCiAR" +
-            "+bf9CjAAluzmdX4AEIIAAAAASUVORK5CYII=\"" +
+            "\"body\": \"iVBORw0KGgoAAAA\"" +
             "}" +
             "]" +
             "}";


### PR DESCRIPTION
- Updates the `.secrets.baseline` and removes any flagged hints of secrets to set an empty baseline
- Updates workflow to fail if any new secrets are added. Previous action only [updates the baseline ](https://github.com/RobertFischer/detect-secrets-action/blob/master/entrypoint.sh#L20) and expects the baseline to be [auto-committed](https://github.com/RobertFischer/detect-secrets-action/tree/master?tab=readme-ov-file#usage-notes) for the delta to be visible. `detect-secrets` provides [`detect-secrets-hook`](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#blocking-secrets-not-in-baseline) to fail on new secrets not found in the baseline. Couldn't find an existing GH action using this tool that fails when new secrets are detected.

closes https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1600