### PR TITLE
feat: Adds kiota authentication dependency into compilation classpath

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@ dependencies {
     api 'com.azure:azure-core:1.51.0'
 
     api 'com.microsoft.kiota:microsoft-kiota-abstractions:1.3.0'
-    implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.3.0'
+    api 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.3.0'
     implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.3.0'
     implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.3.0'
     implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.3.0'


### PR DESCRIPTION
We expose Kiota auth [`ObservabilityOptions`](https://github.com/microsoftgraph/msgraph-sdk-java-core/blob/main/src/main/java/com/microsoft/graph/core/authentication/AzureIdentityAuthenticationProvider.java#L29) in the public API of this package meaning we should add it to the compile classpath as an `api` dependency.

Currently, the kiota-auth module is declared as a [runtime dependency](https://repo1.maven.org/maven2/com/microsoft/graph/microsoft-graph-core/3.1.17/microsoft-graph-core-3.1.17.pom) meaning customers have to take a direct dependency on it.

`maven` projects as in the linked issue currently fail with a compilation error. `gradle` seems to add all dependencies to the compilation classpath.

closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1942

