### PR TITLE
fix: errorMapping in ResponseCodes with "4XX" and "5XX" Pattern

### DIFF
--- a/src/main/java/com/microsoft/graph/core/requests/ResponseBodyHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/ResponseBodyHandler.java
@@ -85,7 +85,7 @@ public class ResponseBodyHandler<T extends Parsable> implements com.microsoft.ki
         } else {
             String statusCodePattern = statusCodeString;
             if (!errorMappings.containsKey(statusCodePattern)) {
-                if (statusCode >= 400 && statusCode <= 499 && errorMappings.containsKey("4XX"))) {
+                if (statusCode >= 400 && statusCode <= 499 && errorMappings.containsKey("4XX")) {
                     statusCodePattern = "4XX";
                 } else if (statusCode >= 500 && statusCode <= 599 && errorMappings.containsKey("5XX")) {
                     statusCodePattern = "5XX";

--- a/src/main/java/com/microsoft/graph/core/requests/ResponseBodyHandler.java
+++ b/src/main/java/com/microsoft/graph/core/requests/ResponseBodyHandler.java
@@ -74,7 +74,7 @@ public class ResponseBodyHandler<T extends Parsable> implements com.microsoft.ki
         int statusCode = nativeResponse.code();
         String statusCodeString = String.valueOf(statusCode);
         if (errorMappings == null ||
-            !errorMappings.containsKey(statusCodeString) ||
+            !errorMappings.containsKey(statusCodeString) &&
             !(statusCode >= 400 && statusCode <= 499 && errorMappings.containsKey("4XX")) &&
                 !(statusCode >= 500 && statusCode <= 599 && errorMappings.containsKey("5XX"))) {
             throw new ApiExceptionBuilder()
@@ -83,7 +83,15 @@ public class ResponseBodyHandler<T extends Parsable> implements com.microsoft.ki
                     .withResponseHeaders(HeadersCompatibility.getResponseHeaders(nativeResponse.headers()))
                     .build();
         } else {
-            Parsable result = parseNode.getObjectValue(errorMappings.get(statusCodeString));
+            String statusCodePattern = statusCodeString;
+            if (!errorMappings.containsKey(statusCodePattern)) {
+                if (statusCode >= 400 && statusCode <= 499 && errorMappings.containsKey("4XX"))) {
+                    statusCodePattern = "4XX";
+                } else if (statusCode >= 500 && statusCode <= 599 && errorMappings.containsKey("5XX")) {
+                    statusCodePattern = "5XX";
+                }
+            }
+            Parsable result = parseNode.getObjectValue(errorMappings.get(statusCodePattern));
             if (!(result instanceof Exception)) {
                 throw new ApiException("The server returned an unexpected status code and the error registered for this code failed to deserialize: " + statusCodeString);
             }


### PR DESCRIPTION
fix: Failed Responses now work with errorMapping with Key "4XX" and "5XX".

### Issues
- Code from the msgraph SDK for Java use for the errorMap Keys a Default of `"4XX"` and `"5XX"` HashMap Key. Since this is not fully supported by core, (but almost implemented) i tried my best at it to implement this 'feature'.

### Changes proposed in this pull request
- Support for Map Keys `"4XX"` and `"5XX"` as fallback Patterns for Statuscodes in the 400s and 500s, if the Specific Code is not a Key in the Error Map.

PS: Im new here in such Big Projects, so i dont know if im at the right address for this issue. I'm open for feedback tho.
