### PR TITLE
Fixes overriding default interceptors and customizing their configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,6 +55,7 @@ android {
         disable "GradleDependency"
         disable "NewerVersionAvailable"
         disable "DuplicatePlatformClasses"      // xpp3 added by azure-identity
+        disable "LambdaLast"
     }
     sourceSets {
         main {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,20 +43,17 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
+
     lintOptions {
         textOutput "stdout"
         checkAllWarnings true
         warningsAsErrors true
-        disable "UnusedResources"              // Unused will be removed on release
-        disable "IconExpectedSize"             // Using the material icons provided from Google
-        disable "GoogleAppIndexingApiWarning"  // We might want to index our app later
-        disable "InvalidPackage"               // Butterknife, Okio and Realm
-        disable "ResourceType"                 // Annotation binding
-        disable "GradleDependency"
-        disable "NewerVersionAvailable"
-        disable "DuplicatePlatformClasses"      // xpp3 added by azure-identity
-        disable "LambdaLast"
+        lintConfig file("lint.xml")
     }
+
     sourceSets {
         main {
             java.srcDirs = ['../src/main/java']

--- a/android/lint-baseline.xml
+++ b/android/lint-baseline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.7.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.2)" variant="all" version="8.7.2">
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in com.azure:azure-xml; not included in Android: `javax.xml.stream`. Referenced from `com.azure.xml.XmlReader`.">
+        <location
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/com.azure/azure-xml/1.1.0/8218a00c07f9f66d5dc7ae2ba613da6890867497/azure-xml-1.1.0.jar"/>
+    </issue>
+
+</issues>

--- a/android/lint.xml
+++ b/android/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="LambdaLast">
+        <ignore path="../src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java" />
+    </issue>
+</lint>

--- a/spotBugsExcludeFilter.xml
+++ b/spotBugsExcludeFilter.xml
@@ -64,6 +64,7 @@ xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubu
 			<Class name="com.microsoft.graph.core.content.BatchResponseContent" />
 			<Class name="com.microsoft.graph.core.requests.ResponseBodyHandler" />
 			<Class name="com.microsoft.graph.core.requests.upload.UploadResponseHandler" />
+			<Class name="com.microsoft.graph.core.requests.middleware.GraphTelemetryHandlerTest" />
 		</Or>
 	</Match>
 	<Match>

--- a/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
+++ b/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
@@ -62,6 +62,12 @@ public class GraphClientFactory {
         return create(authenticationProvider, new RequestOption[0]);
     }
 
+    /**
+     * OkHttpClient Builder for Graph with specified AuthenticationProvider and RequestOptions to override default graph interceptors
+     * @param authenticationProvider the AuthenticationProvider to use for requests.
+     * @param requestOptions custom request options to override default graph interceptors
+     * @return an OkHttpClient Builder instance.
+     */
     @Nonnull
     public static OkHttpClient.Builder create(@Nonnull BaseBearerTokenAuthenticationProvider authenticationProvider, @Nonnull RequestOption[] requestOptions) {
         final GraphClientOption graphClientOption = new GraphClientOption();
@@ -81,9 +87,9 @@ public class GraphClientFactory {
      */
     @Nonnull
     public static OkHttpClient.Builder create(@Nonnull GraphClientOption graphClientOption, @Nonnull Interceptor... interceptors) {
-        var builder = KiotaClientFactory.create(interceptors);
-        var customInterceptors = builder.interceptors();
-        var telemetryHandlerExists = customInterceptors.stream().anyMatch(x -> x instanceof GraphTelemetryHandler);
+        final OkHttpClient.Builder builder = KiotaClientFactory.create(interceptors);
+        final List<Interceptor> customInterceptors = builder.interceptors();
+        final boolean telemetryHandlerExists = customInterceptors.stream().anyMatch(x -> x instanceof GraphTelemetryHandler);
         if (!telemetryHandlerExists) {
             customInterceptors.add(new GraphTelemetryHandler(graphClientOption));
         }
@@ -112,6 +118,12 @@ public class GraphClientFactory {
         return create(graphClientOption, new RequestOption[0]);
     }
 
+    /**
+     * The OkHttpClient Builder with optional GraphClientOption and RequestOptions to override default graph interceptors
+     * @param graphClientOption the GraphClientOption for use in requests.
+     * @param requestOptions custom request options to override default graph interceptors
+     * @return an OkHttpClient Builder instance.
+     */
     @Nonnull
     public static OkHttpClient.Builder create(@Nullable GraphClientOption graphClientOption, @Nonnull RequestOption[] requestOptions) {
         GraphClientOption options = graphClientOption != null ? graphClientOption : new GraphClientOption();
@@ -129,6 +141,12 @@ public class GraphClientFactory {
         return createDefaultGraphInterceptors(graphClientOption, new RequestOption[0]);
     }
 
+    /**
+     * Creates the default Interceptors for use with Graph configured with the provided RequestOptions.
+     * @param graphClientOption the GraphClientOption used to create the GraphTelemetryHandler with.
+     * @param requestOptions custom request options to override default graph interceptors
+     * @return an array of interceptors.
+     */
     @Nonnull
     public static Interceptor[] createDefaultGraphInterceptors(@Nonnull GraphClientOption graphClientOption, @Nonnull RequestOption[] requestOptions) {
         Objects.requireNonNull(requestOptions, "parameter requestOptions cannot be null");
@@ -142,9 +160,7 @@ public class GraphClientFactory {
         }
 
         List<Interceptor> handlers = new ArrayList<>();
-        handlers.add(urlReplaceHandlerOption == null ?
-            new UrlReplaceHandler(new UrlReplaceHandlerOption(CoreConstants.ReplacementConstants.getDefaultReplacementPairs())) :
-            new UrlReplaceHandler(urlReplaceHandlerOption));
+        handlers.add(new UrlReplaceHandler(urlReplaceHandlerOption));
         handlers.add(new GraphTelemetryHandler(graphClientOption));
         handlers.addAll(Arrays.asList(KiotaClientFactory.createDefaultInterceptors(requestOptions)));
         addDefaultFeatureUsages(graphClientOption);

--- a/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
+++ b/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
@@ -37,7 +37,7 @@ public class GraphClientFactory {
      * @return an OkHttpClient Builder instance.
      */
     @Nonnull
-    public static OkHttpClient.Builder create(@Nonnull Interceptor... interceptors) {
+    public static OkHttpClient.Builder create(@Nonnull final Interceptor... interceptors) {
         return create(new GraphClientOption(), interceptors);
     }
 
@@ -47,7 +47,7 @@ public class GraphClientFactory {
      * @return an OkHttpClient Builder instance.
      */
     @Nonnull
-    public static OkHttpClient.Builder create(@Nonnull List<Interceptor> interceptors) {
+    public static OkHttpClient.Builder create(@Nonnull final List<Interceptor> interceptors) {
         return create(new GraphClientOption(), interceptors.toArray(new Interceptor[0]));
     }
 
@@ -58,7 +58,7 @@ public class GraphClientFactory {
      * @return an OkHttpClient Builder instance.
      */
     @Nonnull
-    public static OkHttpClient.Builder create(@Nonnull BaseBearerTokenAuthenticationProvider authenticationProvider) {
+    public static OkHttpClient.Builder create(@Nonnull final BaseBearerTokenAuthenticationProvider authenticationProvider) {
         return create(authenticationProvider, new RequestOption[0]);
     }
 
@@ -69,7 +69,7 @@ public class GraphClientFactory {
      * @return an OkHttpClient Builder instance.
      */
     @Nonnull
-    public static OkHttpClient.Builder create(@Nonnull BaseBearerTokenAuthenticationProvider authenticationProvider, @Nonnull RequestOption[] requestOptions) {
+    public static OkHttpClient.Builder create(@Nonnull final BaseBearerTokenAuthenticationProvider authenticationProvider, @Nonnull final RequestOption[] requestOptions) {
         final GraphClientOption graphClientOption = new GraphClientOption();
         final Interceptor[] interceptors = createDefaultGraphInterceptors(graphClientOption, requestOptions);
         final ArrayList<Interceptor> interceptorList = new ArrayList<>(Arrays.asList(interceptors));
@@ -86,7 +86,7 @@ public class GraphClientFactory {
      * @return an OkHttpClient Builder instance.
      */
     @Nonnull
-    public static OkHttpClient.Builder create(@Nonnull GraphClientOption graphClientOption, @Nonnull Interceptor... interceptors) {
+    public static OkHttpClient.Builder create(@Nonnull final GraphClientOption graphClientOption, @Nonnull final Interceptor... interceptors) {
         final OkHttpClient.Builder builder = KiotaClientFactory.create(interceptors);
         final List<Interceptor> customInterceptors = builder.interceptors();
         final boolean telemetryHandlerExists = customInterceptors.stream().anyMatch(x -> x instanceof GraphTelemetryHandler);
@@ -103,7 +103,7 @@ public class GraphClientFactory {
      * @return an OkHttpClient Builder instance.
      */
     @Nonnull
-    public static OkHttpClient.Builder create(@Nonnull GraphClientOption graphClientOption, @Nonnull List<Interceptor> interceptors) {
+    public static OkHttpClient.Builder create(@Nonnull final GraphClientOption graphClientOption, @Nonnull final List<Interceptor> interceptors) {
         return create(graphClientOption, interceptors.toArray(new Interceptor[0]));
     }
 
@@ -114,7 +114,7 @@ public class GraphClientFactory {
      * @return an OkHttpClient Builder instance.
      */
     @Nonnull
-    public static OkHttpClient.Builder create(@Nullable GraphClientOption graphClientOption) {
+    public static OkHttpClient.Builder create(@Nullable final GraphClientOption graphClientOption) {
         return create(graphClientOption, new RequestOption[0]);
     }
 
@@ -125,7 +125,7 @@ public class GraphClientFactory {
      * @return an OkHttpClient Builder instance.
      */
     @Nonnull
-    public static OkHttpClient.Builder create(@Nullable GraphClientOption graphClientOption, @Nonnull RequestOption[] requestOptions) {
+    public static OkHttpClient.Builder create(@Nullable final GraphClientOption graphClientOption, @Nonnull final RequestOption[] requestOptions) {
         GraphClientOption options = graphClientOption != null ? graphClientOption : new GraphClientOption();
         return KiotaClientFactory.create(createDefaultGraphInterceptors(options, requestOptions));
     }
@@ -137,7 +137,7 @@ public class GraphClientFactory {
      * @return an array of interceptors.
      */
     @Nonnull
-    public static Interceptor[] createDefaultGraphInterceptors(@Nonnull GraphClientOption graphClientOption) {
+    public static Interceptor[] createDefaultGraphInterceptors(@Nonnull final GraphClientOption graphClientOption) {
         return createDefaultGraphInterceptors(graphClientOption, new RequestOption[0]);
     }
 
@@ -148,7 +148,7 @@ public class GraphClientFactory {
      * @return an array of interceptors.
      */
     @Nonnull
-    public static Interceptor[] createDefaultGraphInterceptors(@Nonnull GraphClientOption graphClientOption, @Nonnull RequestOption[] requestOptions) {
+    public static Interceptor[] createDefaultGraphInterceptors(@Nonnull final GraphClientOption graphClientOption, @Nonnull final RequestOption[] requestOptions) {
         Objects.requireNonNull(requestOptions, "parameter requestOptions cannot be null");
 
         UrlReplaceHandlerOption urlReplaceHandlerOption = new UrlReplaceHandlerOption(CoreConstants.ReplacementConstants.getDefaultReplacementPairs());

--- a/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
+++ b/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
@@ -1,6 +1,8 @@
 package com.microsoft.graph.core.requests;
 
+import com.azure.core.credential.TokenCredential;
 import com.microsoft.graph.core.CoreConstants;
+import com.microsoft.graph.core.authentication.AzureIdentityAccessTokenProvider;
 import com.microsoft.graph.core.requests.middleware.GraphTelemetryHandler;
 import com.microsoft.graph.core.requests.options.GraphClientOption;
 import com.microsoft.kiota.RequestOption;
@@ -49,6 +51,27 @@ public class GraphClientFactory {
     @Nonnull
     public static OkHttpClient.Builder create(@Nonnull final List<Interceptor> interceptors) {
         return create(new GraphClientOption(), interceptors.toArray(new Interceptor[0]));
+    }
+
+    /**
+     * OkHttpClient Builder for Graph with authentication middleware that uses the specified TokenCredential.
+     * @param tokenCredential the TokenCredential to use for authentication.
+     * @return an OkHttpClient Builder instance.
+     */
+    @Nonnull
+    public static OkHttpClient.Builder create(@Nonnull final TokenCredential tokenCredential) {
+        return create(tokenCredential, new RequestOption[0]);
+    }
+
+    /**
+     * OkHttpClient Builder for Graph with authentication middleware that uses the specified TokenCredential and RequestOptions to override default graph interceptors.
+     * @param tokenCredential the TokenCredential to use for authentication.
+     * @param requestOptions custom request options to override default graph interceptors
+     * @return an OkHttpClient Builder instance.
+     */
+    @Nonnull
+    public static OkHttpClient.Builder create(@Nonnull final TokenCredential tokenCredential, @Nonnull final RequestOption[] requestOptions) {
+        return create(new BaseBearerTokenAuthenticationProvider(new AzureIdentityAccessTokenProvider(tokenCredential)), requestOptions);
     }
 
     /**

--- a/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
+++ b/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
@@ -140,7 +140,8 @@ public class GraphClientFactory {
      */
     @Nonnull
     public static OkHttpClient.Builder create(@Nullable final GraphClientOption graphClientOption) {
-        return KiotaClientFactory.create(createDefaultGraphInterceptors(graphClientOption));
+        GraphClientOption option = graphClientOption == null ? new GraphClientOption() : graphClientOption;
+        return KiotaClientFactory.create(createDefaultGraphInterceptors(option));
     }
 
     /**

--- a/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
+++ b/src/main/java/com/microsoft/graph/core/requests/GraphClientFactory.java
@@ -75,19 +75,7 @@ public class GraphClientFactory {
      */
     @Nonnull
     public static OkHttpClient.Builder create(@Nonnull GraphClientOption graphClientOption, @Nonnull Interceptor... interceptors) {
-        final OkHttpClient.Builder builder = create(graphClientOption);
-        //Skip adding interceptor if that class of interceptor already exist.
-        final List<String> appliedInterceptors = new ArrayList<>();
-        for(Interceptor interceptor: builder.interceptors()) {
-            appliedInterceptors.add(interceptor.getClass().toString());
-        }
-        for (Interceptor interceptor:interceptors){
-            if(appliedInterceptors.contains(interceptor.getClass().toString())) {
-                continue;
-            }
-            builder.addInterceptor(interceptor);
-        }
-        return builder;
+        return KiotaClientFactory.create(interceptors);
     }
 
     /**

--- a/src/test/java/com/microsoft/graph/core/requests/GraphClientFactoryTest.java
+++ b/src/test/java/com/microsoft/graph/core/requests/GraphClientFactoryTest.java
@@ -16,8 +16,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.azure.core.http.policy.RetryOptions;
-import com.microsoft.graph.core.CoreConstants;
 import com.microsoft.graph.core.authentication.AzureIdentityAccessTokenProvider;
 import com.microsoft.graph.core.authentication.AzureIdentityAuthenticationProvider;
 import com.microsoft.graph.core.requests.middleware.GraphTelemetryHandler;
@@ -89,7 +87,7 @@ class GraphClientFactoryTest {
             new RedirectHandler()};
         final OkHttpClient client = GraphClientFactory.create(interceptors).build();
         final Request request = new Request.Builder().url("https://graph.microsoft.com/v1.0/users/").build();
-        final Response response = client.newCall(request).execute();
+        client.newCall(request).execute();
 
         for (Interceptor clientInterceptor : client.interceptors()) {
             if (clientInterceptor instanceof RetryHandler) {

--- a/src/test/java/com/microsoft/graph/core/requests/middleware/GraphTelemetryHandlerTest.java
+++ b/src/test/java/com/microsoft/graph/core/requests/middleware/GraphTelemetryHandlerTest.java
@@ -6,11 +6,15 @@ import com.microsoft.graph.core.requests.options.GraphClientOption;
 import com.microsoft.kiota.http.middleware.RedirectHandler;
 import com.microsoft.kiota.http.middleware.RetryHandler;
 
+import com.microsoft.kiota.http.middleware.options.RetryHandlerOption;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -30,22 +34,26 @@ class GraphTelemetryHandlerTest {
 
         assertNotNull(response);
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
-        assertTrue(!response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(CoreConstants.Headers.ANDROID_VERSION_PREFIX)); // Android version is not going to be present on unit tests running on java platform
-        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
+        assertTrue(!response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(
+            CoreConstants.Headers.ANDROID_VERSION_PREFIX)); // Android version is not going to be present on unit tests running on java platform
+        assertTrue(
+            response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
     }
 
     @Test
     void arrayInterceptorsTest() throws IOException {
         final String expectedCore = CoreConstants.Headers.GRAPH_VERSION_PREFIX + "/" + CoreConstants.Headers.VERSION;
 
-        final Interceptor[] interceptors = {new GraphTelemetryHandler(), new RetryHandler(), new RedirectHandler()};
+        final Interceptor[] interceptors = {new GraphTelemetryHandler(), new RetryHandler(),
+            new RedirectHandler()};
         final OkHttpClient client = GraphClientFactory.create(interceptors).build();
         final Request request = new Request.Builder().url("https://graph.microsoft.com/v1.0/users/").build();
         final Response response = client.newCall(request).execute();
 
         assertNotNull(response);
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
-        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
+        assertTrue(
+            response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
     }
 
     @Test
@@ -59,7 +67,8 @@ class GraphTelemetryHandlerTest {
 
         assertNotNull(response);
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
-        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
+        assertTrue(
+            response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
     }
 
     @Test
@@ -76,7 +85,7 @@ class GraphTelemetryHandlerTest {
         graphClientOption.setGraphServiceTargetVersion(serviceLibVer);
 
         final String expectedCoreVer =
-            CoreConstants.Headers.GRAPH_VERSION_PREFIX + "/" +coreLibVer;
+            CoreConstants.Headers.GRAPH_VERSION_PREFIX + "/" + coreLibVer;
         final String expectedClientEndpoint =
             CoreConstants.Headers.JAVA_VERSION_PREFIX + "-" + serviceLibVer + "/" + clientLibVer;
 
@@ -85,7 +94,8 @@ class GraphTelemetryHandlerTest {
         final Response response = client.newCall(request).execute();
 
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCoreVer));
-        assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedClientEndpoint));
+        assertTrue(
+            response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedClientEndpoint));
         assertTrue(response.request().header(CoreConstants.Headers.CLIENT_REQUEST_ID).contains(requestId));
     }
 }

--- a/src/test/java/com/microsoft/graph/core/requests/middleware/GraphTelemetryHandlerTest.java
+++ b/src/test/java/com/microsoft/graph/core/requests/middleware/GraphTelemetryHandlerTest.java
@@ -6,13 +6,11 @@ import com.microsoft.graph.core.requests.options.GraphClientOption;
 import com.microsoft.kiota.http.middleware.RedirectHandler;
 import com.microsoft.kiota.http.middleware.RetryHandler;
 
-import com.microsoft.kiota.http.middleware.options.RetryHandlerOption;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,6 +31,8 @@ class GraphTelemetryHandlerTest {
         final Response response = client.newCall(request).execute();
 
         assertNotNull(response);
+        assertNotNull(response.request());
+        assertNotNull(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME));
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
         assertTrue(!response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(
             CoreConstants.Headers.ANDROID_VERSION_PREFIX)); // Android version is not going to be present on unit tests running on java platform
@@ -51,6 +51,8 @@ class GraphTelemetryHandlerTest {
         final Response response = client.newCall(request).execute();
 
         assertNotNull(response);
+        assertNotNull(response.request());
+        assertNotNull(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME));
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
         assertTrue(
             response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
@@ -66,6 +68,8 @@ class GraphTelemetryHandlerTest {
         final Response response = client.newCall(request).execute();
 
         assertNotNull(response);
+        assertNotNull(response.request());
+        assertNotNull(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME));
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCore));
         assertTrue(
             response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(defaultSDKVersion));
@@ -93,6 +97,9 @@ class GraphTelemetryHandlerTest {
         final Request request = new Request.Builder().url("https://graph.microsoft.com/v1.0/users/").build();
         final Response response = client.newCall(request).execute();
 
+        assertNotNull(response);
+        assertNotNull(response.request());
+        assertNotNull(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME));
         assertTrue(response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedCoreVer));
         assertTrue(
             response.request().header(CoreConstants.Headers.SDK_VERSION_HEADER_NAME).contains(expectedClientEndpoint));


### PR DESCRIPTION
Building on the work started in https://github.com/microsoftgraph/msgraph-sdk-java-core/pull/1758.
Thanks @raghusammeta @raghucha 

- Fixes bug in overriding interceptor list
```java
// now works by disregarding the default middleware chain
final OkHttpClient graphClient = GraphClientFactory.create(
   new RetryHandler(), new RedirectHandler()
).build();
```
- Enables configuring default interceptors via passing `RequestOption`. Adds multiple method overloads that accept `RequestOption[]`
```java
final OkHttpClient graphClient = GraphClientFactory.create(new RequestOption[] {new RetryHandlerOption(null, 0, 0)}).build();

Interceptor[] interceptors = GraphClientFactory.createDefaultGraphInterceptors(
    new RequestOption[] {new RetryHandlerOption(null, 0, 0)}
);
// ... and auth overloads
```
- Adds create() overload that accepts a `TokenCredential` to enable auth in the middleware. Reduces steps needed previously to init an auth provider with an AccessTokenProvider etc
```java
final OkHttpClient graphClient = GraphClientFactory.create(tokenCredential).build();
```

closes https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1757