### PR TITLE
[Bug]Fixing missing bytes when processing chunks of a file during upload

### DIFF
--- a/src/test/java/com/microsoft/graph/core/tasks/LargeFileUploadTest.java
+++ b/src/test/java/com/microsoft/graph/core/tasks/LargeFileUploadTest.java
@@ -159,7 +159,7 @@ class LargeFileUploadTest {
         };
 
         // Act
-        UploadResult<TestDriveItem> result = task.upload(3, null);
+        task.upload(3, null);
 
         // Verify the chunkStream content
         ByteArrayInputStream capturedStream = captor.getValue();


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes, as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #1923

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Moved from a single read on `InputStream.read()` to a while loop until read bytes are equal to the InputStream length to ensure the stream is fully read and avoid corrupted bytes when uploading

##Test
Uploaded 5MB file with the current changes no corrupted bytes at the end of the file
![image](https://github.com/user-attachments/assets/6a97df0c-c9ed-4a75-be39-dcdd5cf77a49)

