### PR TITLE
Enable merge groups to avoid manual PR rebasing

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -6,6 +6,7 @@ on:
     branches: [main, support/2.x.x]
   pull_request:
     branches: [main, support/2.x.x]
+  merge_group:
 
 jobs:
   lint-api-level:

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -3,6 +3,7 @@ name: Auto-merge dependabot updates
 on:
   pull_request:
     branches: [ main ]
+  merge_group:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main, support/2.x.x]
+  merge_group:
   schedule:
     - cron: '0 1 * * 4'
   workflow_dispatch:

--- a/.github/workflows/conflicting-pr-label.yml
+++ b/.github/workflows/conflicting-pr-label.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     types: [synchronize]
     branches: [main, support/2.x.x]
+  merge_group:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -3,6 +3,7 @@ name: Java CI with Gradle
 on:
   pull_request:
     branches: [main, support/2.x.x]
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, support/2.x.x]
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 env:
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

This PR applies changes equivalent to those made in https://github.com/microsoft/kiota/pull/6952.

## Original PR
https://github.com/microsoft/kiota/pull/6952 - enables merge groups so we don't have to manually rebase PRs all the time

---
_Generated with Claude Code_