### PR TITLE
Use Maven task in release pipeline

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -106,11 +106,27 @@ extends:
                 inputs:
                   artifactsFeeds: 'GraphDeveloperExperiences_Public'
 
-              - script: ./mvnw install -Psigning --no-transfer-progress
+              - task: Maven@4
                 displayName: Publish to local Maven for verification
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'install'
+                  options: '-Psigning --no-transfer-progress'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
-              - script: ./mvnw deploy -Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy
+              - task: Maven@4
                 displayName: Stage artifacts for ESRP
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'deploy'
+                  options: '-Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
               - pwsh: |
                   $pomXml = [xml](Get-Content pom.xml -Raw)


### PR DESCRIPTION
## Summary
- replace Maven wrapper install/deploy scripts in the release pipeline with `Maven@4`
- preserve signing, staging repository, Azure Artifacts authentication, and JDK 21 settings
- avoid Maven wrapper bootstrap access to Maven Central in network-isolated builds

## Validation
- parsed Azure Pipeline YAML successfully
- verified no `./mvnw` invocation remains under `.azure-pipelines`
- ran `git diff --check`