### PR TITLE
Increase Maven heap for release tasks

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -116,6 +116,7 @@ extends:
                   javaHomeOption: 'JDKVersion'
                   jdkVersionOption: '1.21'
                   jdkArchitectureOption: 'x64'
+                  mavenOptions: '-Xmx3072m'
 
               - task: Maven@4
                 displayName: Stage artifacts for ESRP
@@ -127,6 +128,7 @@ extends:
                   javaHomeOption: 'JDKVersion'
                   jdkVersionOption: '1.21'
                   jdkArchitectureOption: 'x64'
+                  mavenOptions: '-Xmx3072m'
 
               - pwsh: |
                   $pomXml = [xml](Get-Content pom.xml -Raw)

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -106,11 +106,27 @@ extends:
                 inputs:
                   artifactsFeeds: 'GraphDeveloperExperiences_Public'
 
-              - script: ./mvnw install -Psigning --no-transfer-progress
+              - task: Maven@4
                 displayName: Publish to local Maven for verification
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'install'
+                  options: '-Psigning --no-transfer-progress'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
-              - script: ./mvnw deploy -Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy
+              - task: Maven@4
                 displayName: Stage artifacts for ESRP
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'deploy'
+                  options: '-Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
               - pwsh: |
                   $pomXml = [xml](Get-Content pom.xml -Raw)


### PR DESCRIPTION
## Summary
- set `mavenOptions: '-Xmx3072m'` on the release pipeline's Maven install and deploy tasks
- match the existing daily pipeline convention
- prevent `java.lang.OutOfMemoryError: Java heap space` while compiling generated sources

## Validation
- parsed `.azure-pipelines/ci-build.yml` successfully
- ran `git diff --check`

Follow-up to the merged Maven task migration.